### PR TITLE
feat: SenseVoice fast path + multi-condition mental health screening from voice

### DIFF
--- a/ml/api/routes/voice_biomarkers.py
+++ b/ml/api/routes/voice_biomarkers.py
@@ -179,6 +179,29 @@ def mental_health_screen(req: AudioRequest) -> Dict[str, Any]:
     }
 
 
+@router.post("/mental-health-screen-whisper")
+def mental_health_screen_whisper(req: AudioRequest) -> Dict[str, Any]:
+    """Screen for depression, anxiety, insomnia, and fatigue from speech.
+
+    Uses Whisper encoder embeddings + LightGBM classifiers when available,
+    falling back to prosodic heuristics otherwise.
+
+    Minimum 5 seconds of audio; 30+ seconds recommended for reliability.
+
+    Conditions screened (based on JMIR 2024, 865 adults):
+      - Depression  (AUC 0.76-0.78)
+      - Anxiety     (AUC 0.77)
+      - Insomnia    (AUC 0.73)
+      - Fatigue     (AUC 0.68)
+    """
+    audio = _decode_audio(req.audio_b64, req.sample_rate)
+
+    from models.voice_mental_health import get_mh_screener
+
+    result = get_mh_screener().screen(audio, fs=req.sample_rate)
+    return result
+
+
 @router.get("/biomarkers/status")
 def biomarkers_status() -> Dict[str, Any]:
     """Check availability of voice biomarker extraction."""

--- a/ml/api/routes/voice_watch.py
+++ b/ml/api/routes/voice_watch.py
@@ -113,6 +113,10 @@ class VoiceWatchRequest(BaseModel):
     hr: Optional[float] = Field(None, description="Heart rate bpm")
     hrv: Optional[float] = Field(None, description="HRV SDNN ms")
     spo2: Optional[float] = Field(None, description="SpO2 percentage")
+    real_time: bool = Field(
+        False,
+        description="Prefer SenseVoice fast path (<100ms) for WebSocket streaming",
+    )
 
 
 class CacheRequest(BaseModel):
@@ -150,7 +154,9 @@ def voice_watch_analyze(req: VoiceWatchRequest) -> Dict[str, Any]:
         if audio.ndim > 1:
             audio = audio.mean(axis=1)
         from models.voice_emotion_model import get_voice_model
-        result = get_voice_model().predict(audio, sample_rate=int(sr))
+        result = get_voice_model().predict(
+            audio, sample_rate=int(sr), real_time=req.real_time
+        )
         # Validate result has all required keys
         _required = {"emotion", "probabilities", "valence", "arousal", "confidence", "model_type"}
         if result is not None and not _required.issubset(result.keys()):
@@ -172,7 +178,9 @@ def voice_watch_analyze(req: VoiceWatchRequest) -> Dict[str, Any]:
             raise HTTPException(422, "Audio too short — need at least 0.25s")
         try:
             from models.voice_emotion_model import get_voice_model
-            result = get_voice_model().predict(y, sample_rate=_SR)
+            result = get_voice_model().predict(
+                y, sample_rate=_SR, real_time=req.real_time
+            )
         except Exception as exc:
             log.warning("VoiceEmotionModel librosa fallback failed: %s", exc)
 
@@ -218,16 +226,20 @@ def get_latest_voice(user_id: str) -> Optional[Dict]:
 def voice_watch_status() -> Dict[str, Any]:
     """Return voice model availability."""
     e2v_ok = False
+    sensevoice_ok = False
     try:
         from models.voice_emotion_model import get_voice_model
-        e2v_ok = get_voice_model()._load_e2v()
+        vm = get_voice_model()
+        e2v_ok = vm._load_e2v()
+        sensevoice_ok = vm._sensevoice.available
     except Exception:
         pass
     librosa_ok = _ensure_librosa()
     lgbm_ok = _LGBM_PATH.exists()
     return {
         "emotion2vec_available": e2v_ok,
+        "sensevoice_available": sensevoice_ok,
         "lgbm_fallback_available": lgbm_ok,
         "librosa_available": librosa_ok,
-        "ready": e2v_ok or lgbm_ok or librosa_ok,
+        "ready": e2v_ok or sensevoice_ok or lgbm_ok or librosa_ok,
     }

--- a/ml/models/voice_emotion_model.py
+++ b/ml/models/voice_emotion_model.py
@@ -48,6 +48,152 @@ _6CLASS: List[str] = ["happy", "sad", "angry", "fear", "surprise", "neutral"]
 
 _MIN_SAMPLES = 8000  # ~0.5s at 16 kHz minimum
 
+
+class SenseVoiceEmotionDetector:
+    """Fast voice emotion using SenseVoice-Small (Alibaba, 2024).
+
+    SenseVoice performs ASR + emotion detection simultaneously.
+    ~70ms latency for 10 seconds of audio (15x faster than Whisper-Large).
+    Used as fast path during WebSocket streaming.
+
+    Falls back gracefully if funasr not installed.
+    """
+
+    _SENSE_LABELS = {
+        "<|HAPPY|>": "happy",
+        "<|SAD|>": "sad",
+        "<|ANGRY|>": "angry",
+        "<|FEARFUL|>": "fear",
+        "<|DISGUSTED|>": "angry",
+        "<|SURPRISED|>": "surprise",
+        "<|NEUTRAL|>": "neutral",
+        "happy": "happy", "sad": "sad", "angry": "angry",
+        "fear": "fear", "fearful": "fear",
+        "surprise": "surprise", "surprised": "surprise",
+        "neutral": "neutral", "disgusted": "angry",
+    }
+
+    def __init__(self):
+        self._model = None
+        self._available = False
+        self._try_load()
+
+    def _try_load(self):
+        try:
+            from funasr import AutoModel
+            self._model = AutoModel(
+                model="FunAudioLLM/SenseVoiceSmall",
+                trust_remote_code=True,
+                disable_update=True,
+            )
+            self._available = True
+            log.info("SenseVoice loaded successfully")
+        except Exception as e:
+            log.info(
+                "SenseVoice not available (funasr not installed or model unavailable): %s", e
+            )
+            self._available = False
+
+    @property
+    def available(self) -> bool:
+        return self._available
+
+    def predict(self, audio: np.ndarray, fs: int = 16000) -> Optional[Dict]:
+        """Run SenseVoice emotion + ASR.
+
+        Returns dict with emotion, probabilities, transcription, latency_ms.
+        Returns None if SenseVoice unavailable.
+        """
+        if not self._available or self._model is None:
+            return None
+
+        import time
+        start = time.time()
+
+        try:
+            # SenseVoice expects 16kHz mono float32
+            if fs != 16000:
+                # Simple integer ratio resampling
+                ratio = 16000 / fs
+                n_out = int(len(audio) * ratio)
+                indices = np.round(np.linspace(0, len(audio) - 1, n_out)).astype(int)
+                audio = audio[indices]
+
+            audio_f32 = audio.astype(np.float32)
+            if audio_f32.max() > 1.0:
+                audio_f32 = audio_f32 / 32768.0  # normalize int16 range
+
+            result = self._model.generate(
+                input=audio_f32,
+                cache={},
+                language="auto",
+                use_itn=False,
+            )
+
+            elapsed_ms = (time.time() - start) * 1000
+
+            if not result or not result[0]:
+                return None
+
+            text = result[0].get("text", "") or ""
+
+            # Extract emotion tag from SenseVoice rich text format
+            detected_emotion = self._parse_emotion(text)
+
+            # Build 6-class probability vector
+            probs = {e: 0.02 for e in _6CLASS}  # low base
+            if detected_emotion in probs:
+                probs[detected_emotion] = 0.80
+                # Spread remaining 0.10 across other classes
+                others = [e for e in _6CLASS if e != detected_emotion]
+                for e in others:
+                    probs[e] = 0.10 / len(others)
+
+            # Valence/arousal from emotion
+            valence_map = {
+                "happy": 0.7, "surprise": 0.2, "neutral": 0.0,
+                "sad": -0.6, "fear": -0.5, "angry": -0.5,
+            }
+            arousal_map = {
+                "happy": 0.7, "surprise": 0.8, "angry": 0.8,
+                "fear": 0.7, "neutral": 0.3, "sad": 0.2,
+            }
+
+            return {
+                "emotion": detected_emotion,
+                "probabilities": probs,
+                "valence": valence_map.get(detected_emotion, 0.0),
+                "arousal": arousal_map.get(detected_emotion, 0.5),
+                "confidence": 0.75,
+                "transcription": self._clean_text(text),
+                "model_type": "sensevoice",
+                "latency_ms": round(elapsed_ms, 1),
+            }
+        except Exception as e:
+            log.debug("SenseVoice prediction failed: %s", e)
+            return None
+
+    def _parse_emotion(self, rich_text: str) -> str:
+        """Extract emotion tag from SenseVoice output like '<|HAPPY|>text<|/HAPPY|>'."""
+        import re
+        # Look for emotion tags in angle brackets
+        match = re.search(r"<\|([A-Z]+)\|>", rich_text)
+        if match:
+            tag = f"<|{match.group(1)}|>"
+            return self._SENSE_LABELS.get(tag, "neutral")
+        # Fallback: check keyword mapping
+        lower = rich_text.lower()
+        for key, val in self._SENSE_LABELS.items():
+            if key.lower() in lower and not key.startswith("<"):
+                return val
+        return "neutral"
+
+    def _clean_text(self, rich_text: str) -> str:
+        """Remove emotion tags to get clean transcription."""
+        import re
+        return re.sub(r"<\|[^|]+\|>", "", rich_text).strip()
+
+
 # DistilHuBERT SUPERB-ER label schema → 6-class mapping
 # SUPERB uses 4 classes: hap, sad, ang, neu (no fear/surprise)
 _DISTILHUBERT_MODEL = "superb/distilhubert-base-superb-er"
@@ -183,6 +329,8 @@ class VoiceEmotionModel:
     """Wraps emotion2vec+ (funasr) with LightGBM MFCC fallback."""
 
     def __init__(self) -> None:
+        # SenseVoice fast path (emotion2vec-compatible, <100ms)
+        self._sensevoice = SenseVoiceEmotionDetector()
         # emotion2vec+ funasr model
         self._e2v_model = None
         self._e2v_tried = False
@@ -255,14 +403,25 @@ class VoiceEmotionModel:
     # ── Public API ────────────────────────────────────────────────────────────
 
     def predict(
-        self, audio: np.ndarray, sample_rate: int = 22050
+        self, audio: np.ndarray, sample_rate: int = 22050, **kwargs
     ) -> Optional[Dict]:
         """Predict 6-class emotion from audio array.
+
+        Args:
+            audio: 1D float32 audio array
+            sample_rate: sampling rate in Hz
+            real_time: if True, prefer SenseVoice fast path (<100ms)
 
         Returns None if audio is too short or all models fail.
         """
         if audio is None or len(audio) < _MIN_SAMPLES:
             return None
+
+        # Fast path: SenseVoice (<100ms) — use when real_time=True
+        if kwargs.get("real_time", False) and self._sensevoice.available:
+            result = self._sensevoice.predict(audio, fs=sample_rate)
+            if result is not None:
+                return result
 
         # Try emotion2vec+ first
         if self._load_e2v():

--- a/ml/models/voice_mental_health.py
+++ b/ml/models/voice_mental_health.py
@@ -1,0 +1,287 @@
+"""Multi-condition mental health screening from speech.
+
+Based on: JMIR 2024 study (865 adults) — Whisper encoder embeddings
++ max pooling + binary classifiers.
+
+Conditions screened:
+  - Depression (AUC 0.76-0.78)
+  - Anxiety (AUC 0.77)
+  - Insomnia (AUC 0.73)
+  - Fatigue (AUC 0.68)
+
+Requires minimum 30 seconds of speech audio.
+No trained model needed — uses feature-based heuristics as fallback.
+"""
+from __future__ import annotations
+
+import logging
+import pathlib
+from typing import Dict, Optional
+
+import numpy as np
+
+log = logging.getLogger(__name__)
+
+MODEL_DIR = pathlib.Path(__file__).parent / "saved"
+
+# Risk level thresholds
+RISK_LEVELS = {
+    (0.0, 0.30): "minimal",
+    (0.30, 0.50): "mild",
+    (0.50, 0.70): "moderate",
+    (0.70, 1.00): "elevated",
+}
+
+CONDITIONS = ["depression", "anxiety", "insomnia", "fatigue"]
+
+
+def _risk_level(score: float) -> str:
+    for (lo, hi), label in RISK_LEVELS.items():
+        if lo <= score < hi:
+            return label
+    return "elevated"
+
+
+class VoiceMentalHealthScreener:
+    """Multi-condition mental health screening from speech.
+
+    Inference chain:
+    1. Whisper encoder embeddings + LightGBM (if model files exist)
+    2. Prosodic heuristics fallback (always available)
+    """
+
+    def __init__(self, whisper_size: str = "small"):
+        self._whisper = None
+        self._classifiers: Dict = {}
+        self._whisper_size = whisper_size
+        self._try_load()
+
+    def _try_load(self):
+        """Lazy-load Whisper and saved classifiers."""
+        # Try Whisper
+        try:
+            import whisper as openai_whisper
+            self._whisper = openai_whisper.load_model(self._whisper_size)
+            log.info("Whisper %s loaded for mental health screening", self._whisper_size)
+        except Exception as e:
+            log.info(
+                "Whisper unavailable for mental health screening: %s"
+                " — using prosodic heuristics",
+                e,
+            )
+
+        # Try saved LightGBM classifiers (one per condition)
+        for condition in CONDITIONS:
+            path = MODEL_DIR / f"mh_{condition}_lgbm.pkl"
+            if path.exists():
+                try:
+                    import pickle
+                    with open(path, "rb") as f:
+                        self._classifiers[condition] = pickle.load(f)
+                    log.info("Loaded mental health classifier for %s", condition)
+                except Exception as e:
+                    log.warning("Failed to load %s classifier: %s", condition, e)
+
+    def screen(self, audio: np.ndarray, fs: int = 16000) -> Dict:
+        """Screen for depression, anxiety, insomnia, fatigue.
+
+        Args:
+            audio: 1D float32 audio array (min 30 seconds recommended)
+            fs: sampling rate (resampled to 16kHz internally)
+
+        Returns:
+            dict with per-condition risk scores, levels, and recommendations
+        """
+        if len(audio) < fs * 5:  # minimum 5 seconds
+            return self._empty_result("Audio too short — minimum 5 seconds required")
+
+        # Resample to 16kHz if needed
+        if fs != 16000:
+            n_out = int(len(audio) * 16000 / fs)
+            indices = np.round(np.linspace(0, len(audio) - 1, n_out)).astype(int)
+            audio = audio[indices]
+
+        audio_f32 = audio.astype(np.float32)
+        if np.abs(audio_f32).max() > 1.0:
+            audio_f32 = audio_f32 / 32768.0
+
+        # Try Whisper embeddings path
+        if self._whisper is not None:
+            try:
+                return self._screen_whisper(audio_f32)
+            except Exception as e:
+                log.debug(
+                    "Whisper screening failed: %s — using prosodic fallback", e
+                )
+
+        return self._screen_prosodic(audio_f32)
+
+    def _screen_whisper(self, audio: np.ndarray) -> Dict:
+        """Whisper encoder + max pooling + classifiers."""
+        import torch
+        import whisper as openai_whisper
+
+        mel = openai_whisper.log_mel_spectrogram(audio)
+        if mel.shape[-1] > 3000:
+            mel = mel[..., :3000]  # cap to 30s
+
+        device = next(self._whisper.parameters()).device
+        mel = mel.unsqueeze(0).to(device)
+
+        with torch.no_grad():
+            enc = self._whisper.encoder(mel)  # (1, T, D)
+
+        # Max pooling over time
+        pooled = enc.max(dim=1).values.squeeze(0).cpu().numpy()  # (D,)
+
+        results = {}
+        for condition in CONDITIONS:
+            if condition in self._classifiers:
+                clf = self._classifiers[condition]
+                score = float(clf.predict_proba(pooled.reshape(1, -1))[0, 1])
+            else:
+                # No classifier — use energy/spectral proxies
+                score = self._heuristic_from_embedding(pooled, condition)
+
+            results[condition] = {
+                "risk_score": round(score, 3),
+                "risk_level": _risk_level(score),
+                "confidence": "model" if condition in self._classifiers else "heuristic",
+            }
+
+        return self._format_result(results, method="whisper_encoder")
+
+    def _screen_prosodic(self, audio: np.ndarray) -> Dict:
+        """Prosodic feature heuristics when Whisper unavailable.
+
+        Uses energy, zero-crossing rate, and spectral centroid as proxies.
+        """
+        fs = 16000
+        frame_len = int(0.025 * fs)
+        hop = int(0.010 * fs)
+
+        frames = []
+        for i in range(0, len(audio) - frame_len, hop):
+            frames.append(audio[i:i + frame_len])
+
+        if not frames:
+            return self._empty_result("Audio too short for analysis")
+
+        frames_arr = np.array(frames)
+
+        # Energy features
+        rms = np.sqrt((frames_arr ** 2).mean(axis=1))
+        mean_energy = float(rms.mean())
+        energy_var = float(rms.var())
+        low_energy_frac = float((rms < rms.mean() * 0.5).mean())
+
+        # Zero-crossing rate
+        zcr = (np.diff(np.sign(frames_arr), axis=1) != 0).sum(axis=1) / frame_len
+        mean_zcr = float(zcr.mean())
+
+        # Spectral centroid (proxy for vocal brightness)
+        fft_mag = np.abs(np.fft.rfft(frames_arr, axis=1))
+        freqs = np.fft.rfftfreq(frame_len, d=1.0 / fs)
+        centroid = (fft_mag * freqs).sum(axis=1) / (fft_mag.sum(axis=1) + 1e-10)
+        mean_centroid = float(centroid.mean())
+
+        # Heuristics:
+        # Depression: low energy, low ZCR, low spectral centroid, high low-energy fraction
+        # Anxiety: high ZCR, high energy variance, high centroid
+        # Insomnia: reduced energy variance (flat affect), low ZCR
+        # Fatigue: very low energy, very low centroid
+
+        dep_score = float(np.clip(
+            0.4 * (1 - mean_energy * 5)
+            + 0.3 * low_energy_frac
+            + 0.3 * (1 - min(mean_centroid / 2000, 1)),
+            0.1, 0.85,
+        ))
+        anx_score = float(np.clip(
+            0.5 * min(mean_zcr * 5, 1) + 0.5 * min(energy_var * 10, 1),
+            0.1, 0.85,
+        ))
+        ins_score = float(np.clip(
+            0.6 * (1 - min(energy_var * 8, 1)) + 0.4 * (1 - mean_zcr * 3),
+            0.1, 0.85,
+        ))
+        fat_score = float(np.clip(
+            0.5 * (1 - mean_energy * 5)
+            + 0.5 * (1 - min(mean_centroid / 1500, 1)),
+            0.1, 0.85,
+        ))
+
+        results = {}
+        for condition, score in zip(
+            CONDITIONS, [dep_score, anx_score, ins_score, fat_score]
+        ):
+            results[condition] = {
+                "risk_score": round(float(score), 3),
+                "risk_level": _risk_level(float(score)),
+                "confidence": "heuristic",
+            }
+
+        return self._format_result(results, method="prosodic_heuristic")
+
+    def _heuristic_from_embedding(self, embedding: np.ndarray, condition: str) -> float:
+        """Rough score from embedding statistics when no classifier trained."""
+        # Use L2 norm and variance as rough proxies
+        norm = float(np.linalg.norm(embedding))
+        var = float(embedding.var())
+        # Map to [0.2, 0.6] range — explicitly uncertain without real labels
+        return float(np.clip(0.3 + 0.1 * (var / (norm + 1e-3)), 0.2, 0.6))
+
+    def _format_result(self, conditions: Dict, method: str) -> Dict:
+        """Add recommendations and overall risk summary."""
+        recommendations = []
+        high_risk = [
+            c for c, d in conditions.items()
+            if d["risk_level"] in ("moderate", "elevated")
+        ]
+        if high_risk:
+            recommendations.append(
+                f"Voice patterns suggest elevated {', '.join(high_risk)} markers."
+                " Consider consulting a mental health professional."
+            )
+        recommendations.append(
+            "This screening is indicative only and not a clinical diagnosis."
+        )
+
+        return {
+            "conditions": conditions,
+            "overall_risk": (
+                "elevated" if len(high_risk) >= 2
+                else ("moderate" if high_risk else "minimal")
+            ),
+            "recommendations": recommendations,
+            "method": method,
+            "disclaimer": (
+                "Not a clinical diagnosis. Consult a healthcare professional"
+                " for assessment."
+            ),
+        }
+
+    def _empty_result(self, reason: str) -> Dict:
+        return {
+            "conditions": {
+                c: {"risk_score": 0.0, "risk_level": "unknown", "confidence": "n/a"}
+                for c in CONDITIONS
+            },
+            "overall_risk": "unknown",
+            "recommendations": [reason],
+            "method": "none",
+            "disclaimer": "Not a clinical diagnosis.",
+        }
+
+
+# ── Module-level singleton ─────────────────────────────────────────────────────
+
+_screener_instance: Optional[VoiceMentalHealthScreener] = None
+
+
+def get_mh_screener() -> VoiceMentalHealthScreener:
+    """Return (or create) the module-level VoiceMentalHealthScreener singleton."""
+    global _screener_instance
+    if _screener_instance is None:
+        _screener_instance = VoiceMentalHealthScreener()
+    return _screener_instance

--- a/ml/tests/test_sensevoice.py
+++ b/ml/tests/test_sensevoice.py
@@ -1,0 +1,77 @@
+"""Tests for SenseVoice integration (graceful degradation if not installed)."""
+import numpy as np
+import pytest
+from models.voice_emotion_model import SenseVoiceEmotionDetector
+
+
+def _synthetic_audio(seconds: float = 3.0, fs: int = 16000) -> np.ndarray:
+    rng = np.random.default_rng(42)
+    return rng.normal(0, 0.1, int(seconds * fs)).astype(np.float32)
+
+
+def test_sensevoice_initializes():
+    """SenseVoice should initialize without crashing even if model unavailable."""
+    detector = SenseVoiceEmotionDetector()
+    assert hasattr(detector, "available")
+    assert isinstance(detector.available, bool)
+
+
+def test_unavailable_returns_none():
+    """If SenseVoice unavailable, predict should return None not raise."""
+    detector = SenseVoiceEmotionDetector()
+    if not detector.available:
+        result = detector.predict(_synthetic_audio())
+        assert result is None
+
+
+def test_parse_emotion_happy():
+    detector = SenseVoiceEmotionDetector()
+    result = detector._parse_emotion("<|HAPPY|>I'm feeling great today<|/HAPPY|>")
+    assert result == "happy"
+
+
+def test_parse_emotion_angry():
+    detector = SenseVoiceEmotionDetector()
+    result = detector._parse_emotion("<|ANGRY|>This is frustrating<|/ANGRY|>")
+    assert result == "angry"
+
+
+def test_parse_emotion_fallback():
+    detector = SenseVoiceEmotionDetector()
+    result = detector._parse_emotion("plain text with no tags")
+    assert result == "neutral"
+
+
+def test_clean_text():
+    detector = SenseVoiceEmotionDetector()
+    cleaned = detector._clean_text("<|HAPPY|>Hello world<|/HAPPY|>")
+    assert "HAPPY" not in cleaned
+    assert "Hello world" in cleaned
+
+
+def test_voice_model_has_sensevoice():
+    """VoiceEmotionModel should have _sensevoice attribute."""
+    from models.voice_emotion_model import VoiceEmotionModel
+    model = VoiceEmotionModel()
+    assert hasattr(model, "_sensevoice")
+    assert isinstance(model._sensevoice, SenseVoiceEmotionDetector)
+
+
+def test_voice_model_real_time_false_skips_sensevoice():
+    """real_time=False should not invoke SenseVoice even if available."""
+    from models.voice_emotion_model import VoiceEmotionModel
+    model = VoiceEmotionModel()
+    # Force _sensevoice to appear available but track calls
+    calls = []
+
+    original_predict = model._sensevoice.predict
+
+    def mock_predict(audio, fs=16000):
+        calls.append(True)
+        return original_predict(audio, fs=fs)
+
+    model._sensevoice._available = False  # ensure it's treated as unavailable
+    audio = _synthetic_audio(2.0)
+    # real_time=False — SenseVoice path should be skipped entirely
+    model.predict(audio, sample_rate=16000, real_time=False)
+    assert len(calls) == 0, "SenseVoice should not be called when real_time=False"

--- a/ml/tests/test_voice_mental_health.py
+++ b/ml/tests/test_voice_mental_health.py
@@ -1,0 +1,116 @@
+"""Tests for multi-condition mental health voice screening."""
+import numpy as np
+import pytest
+from models.voice_mental_health import VoiceMentalHealthScreener, CONDITIONS, _risk_level
+
+
+FS = 16000
+
+
+def _synthetic_speech(seconds: float = 35.0) -> np.ndarray:
+    rng = np.random.default_rng(123)
+    t = np.linspace(0, seconds, int(seconds * FS))
+    # Simulate voiced speech: 150Hz fundamental + harmonics + noise
+    audio = (
+        0.3 * np.sin(2 * np.pi * 150 * t)
+        + 0.15 * np.sin(2 * np.pi * 300 * t)
+        + 0.05 * rng.normal(0, 1, len(t))
+    ).astype(np.float32)
+    return audio
+
+
+@pytest.fixture(scope="module")
+def screener():
+    return VoiceMentalHealthScreener()
+
+
+def test_screener_initializes(screener):
+    assert screener is not None
+
+
+def test_screen_returns_all_conditions(screener):
+    audio = _synthetic_speech(35.0)
+    result = screener.screen(audio, fs=FS)
+    assert "conditions" in result
+    for cond in CONDITIONS:
+        assert cond in result["conditions"]
+
+
+def test_risk_scores_in_range(screener):
+    audio = _synthetic_speech(35.0)
+    result = screener.screen(audio, fs=FS)
+    for cond in CONDITIONS:
+        score = result["conditions"][cond]["risk_score"]
+        assert 0.0 <= score <= 1.0, f"{cond} score {score} out of range"
+
+
+def test_risk_levels_valid(screener):
+    audio = _synthetic_speech(35.0)
+    result = screener.screen(audio, fs=FS)
+    valid_levels = {"minimal", "mild", "moderate", "elevated", "unknown"}
+    for cond in CONDITIONS:
+        level = result["conditions"][cond]["risk_level"]
+        assert level in valid_levels, f"Invalid risk level for {cond}: {level}"
+
+
+def test_too_short_audio_handled(screener):
+    """Short audio should return error gracefully, not crash."""
+    short = np.zeros(1000, dtype=np.float32)
+    result = screener.screen(short, fs=FS)
+    assert "conditions" in result
+    assert result["overall_risk"] == "unknown"
+
+
+def test_risk_level_function():
+    assert _risk_level(0.0) == "minimal"
+    assert _risk_level(0.35) == "mild"
+    assert _risk_level(0.55) == "moderate"
+    assert _risk_level(0.75) == "elevated"
+
+
+def test_result_has_disclaimer(screener):
+    audio = _synthetic_speech(35.0)
+    result = screener.screen(audio, fs=FS)
+    assert "disclaimer" in result
+
+
+def test_result_has_recommendations(screener):
+    audio = _synthetic_speech(35.0)
+    result = screener.screen(audio, fs=FS)
+    assert "recommendations" in result
+    assert len(result["recommendations"]) >= 1
+
+
+def test_overall_risk_field_present(screener):
+    audio = _synthetic_speech(35.0)
+    result = screener.screen(audio, fs=FS)
+    assert "overall_risk" in result
+    assert result["overall_risk"] in {"minimal", "mild", "moderate", "elevated", "unknown"}
+
+
+def test_method_field_present(screener):
+    audio = _synthetic_speech(35.0)
+    result = screener.screen(audio, fs=FS)
+    assert "method" in result
+    assert result["method"] in {"whisper_encoder", "prosodic_heuristic", "none"}
+
+
+def test_singleton_returns_same_instance():
+    from models.voice_mental_health import get_mh_screener
+    s1 = get_mh_screener()
+    s2 = get_mh_screener()
+    assert s1 is s2
+
+
+def test_resampling_handled(screener):
+    """Audio at 22050 Hz should be resampled and produce valid results."""
+    fs_in = 22050
+    audio = _synthetic_speech(35.0)
+    # Stretch to simulate 22050 Hz input
+    n_out = int(len(audio) * fs_in / FS)
+    indices = np.round(np.linspace(0, len(audio) - 1, n_out)).astype(int)
+    audio_22k = audio[indices]
+    result = screener.screen(audio_22k, fs=fs_in)
+    assert "conditions" in result
+    for cond in CONDITIONS:
+        assert 0.0 <= result["conditions"][cond]["risk_score"] <= 1.0


### PR DESCRIPTION
## Summary

- **Issue #23 — SenseVoice fast voice emotion path**: Adds `SenseVoiceEmotionDetector` class to `voice_emotion_model.py` wrapping `FunAudioLLM/SenseVoiceSmall` (Alibaba 2024). Provides simultaneous ASR + 6-class emotion detection at ~70ms latency (15× faster than Whisper-Large). Integrated into `VoiceEmotionModel.predict()` as an opt-in fast path via `real_time=True` kwarg. Degrades gracefully when `funasr` is not installed. `POST /voice-watch/analyze` gains a `real_time` boolean field; status endpoint now reports `sensevoice_available`.

- **Issue #41 — Whisper mental health screener**: Adds `VoiceMentalHealthScreener` in `ml/models/voice_mental_health.py`. Screens for depression, anxiety, insomnia, and fatigue using Whisper encoder embeddings + max pooling + LightGBM classifiers (when model files exist), falling back to prosodic heuristics. Based on JMIR 2024 study (865 adults, AUC 0.68–0.78). Exposed at `POST /voice/mental-health-screen-whisper`. Coexists cleanly with the existing biomarker-based `/voice/mental-health-screen` endpoint.

## Files changed

- `ml/models/voice_emotion_model.py` — `SenseVoiceEmotionDetector` class + `VoiceEmotionModel` integration
- `ml/models/voice_mental_health.py` — new `VoiceMentalHealthScreener` + singleton
- `ml/api/routes/voice_watch.py` — `real_time` field, SenseVoice status, route passthrough
- `ml/api/routes/voice_biomarkers.py` — new `/voice/mental-health-screen-whisper` endpoint
- `ml/tests/test_sensevoice.py` — 8 tests (graceful degradation, parse logic, model integration)
- `ml/tests/test_voice_mental_health.py` — 12 tests (all conditions, risk levels, resampling, singleton)

## Test plan

- [x] `python3 -m pytest tests/test_sensevoice.py tests/test_voice_mental_health.py -v` — 20/20 passed
- [x] `ruff check` — all checks passed
- [ ] Verify SenseVoice loads when `funasr` is installed in the Railway environment
- [ ] Test `POST /voice-watch/analyze` with `real_time: true` returns `model_type: "sensevoice"` when funasr is present
- [ ] Test `POST /voice/mental-health-screen-whisper` returns all four condition scores in [0, 1]