### PR TITLE
feat: brain age estimation + sleep memory consolidation (#59, #62)

### DIFF
--- a/ml/api/routes/cognitive.py
+++ b/ml/api/routes/cognitive.py
@@ -163,6 +163,76 @@ async def cognitive_session_stats():
     return _numpy_safe(stats)
 
 
+# ── Brain Age Estimation ──────────────────────────────────────────────────────
+
+from typing import List, Optional
+from pydantic import BaseModel, Field
+
+from models.brain_age_estimator import get_brain_age_estimator
+
+
+class BrainAgeRequest(BaseModel):
+    signals: List[List[float]] = Field(..., description="EEG signals (channels x samples)")
+    fs: float = Field(default=256.0, description="Sampling frequency in Hz")
+    user_id: str = Field(default="default")
+    chronological_age: Optional[float] = Field(
+        default=None, description="User's actual age in years (enables gap calculation)"
+    )
+
+
+@router.post("/brain-age")
+async def estimate_brain_age(req: BrainAgeRequest):
+    """Estimate biological brain age from EEG aperiodic features.
+
+    Returns predicted_age, brain_age_gap (if chronological_age provided),
+    and aperiodic spectral features. Wellness indicator only — not medical.
+    """
+    signals = np.array(req.signals)
+    estimator = get_brain_age_estimator()
+    result = estimator.predict(signals, req.fs, chronological_age=req.chronological_age)
+    return _numpy_safe(result)
+
+
+# ── Sleep Memory Consolidation ─────────────────────────────────────────────
+
+from models.memory_consolidation_tracker import get_memory_tracker
+
+
+class MemoryEpochRequest(BaseModel):
+    signals: List[List[float]] = Field(..., description="EEG signals (channels x samples)")
+    fs: float = Field(default=256.0, description="Sampling frequency in Hz")
+    user_id: str = Field(default="default")
+    sleep_stage: str = Field(default="N2", description="Current sleep stage: N1, N2, N3, REM, Wake")
+
+
+@router.post("/sleep/memory-consolidation/epoch")
+async def score_memory_epoch(req: MemoryEpochRequest):
+    """Score one sleep epoch for memory consolidation quality.
+
+    Use during sleep recording. Provide sleep_stage for accurate weighting.
+    Returns spindle density, SO-spindle coupling, and consolidation quality.
+    """
+    signals = np.array(req.signals)
+    tracker = get_memory_tracker(req.user_id)
+    result = tracker.score_epoch(signals, req.fs, req.sleep_stage)
+    return _numpy_safe(result)
+
+
+@router.get("/sleep/memory-consolidation/session/{user_id}")
+async def get_memory_session(user_id: str):
+    """Get memory consolidation summary for the current sleep session."""
+    tracker = get_memory_tracker(user_id)
+    return tracker.score_session()
+
+
+@router.post("/sleep/memory-consolidation/tmr-check")
+async def check_tmr_trigger(req: MemoryEpochRequest):
+    """Check if current moment is good for TMR audio cue (SO up-state detection)."""
+    signals = np.array(req.signals)
+    tracker = get_memory_tracker(req.user_id)
+    return tracker.get_tmr_trigger(signals, req.fs, req.sleep_stage)
+
+
 @router.post("/voice-cognitive-load")
 async def voice_cognitive_load(request: dict):
     """Estimate cognitive load from voice prosodic features.

--- a/ml/models/brain_age_estimator.py
+++ b/ml/models/brain_age_estimator.py
@@ -1,0 +1,199 @@
+"""Brain Age Estimation from 4-channel Muse 2 EEG.
+
+Uses aperiodic spectral features (1/f slope) + band powers to estimate biological
+brain age. Outputs Brain Age Gap = predicted_age - chronological_age.
+
+Scientific basis:
+- Banville et al. (2024, MIT Press): R²=0.3-0.5 using Muse S headband (n=5,200+)
+- PMC 12321796 (2025): Aperiodic exponent top predictor via Shapley analysis
+- Aperiodic exponent (1/f slope) decreases with age — measurable with 4 channels
+- Brain Age Gap: positive = accelerated neural aging, negative = younger-than-expected
+
+DISCLAIMER: This is a wellness indicator. Not a medical diagnosis.
+"""
+from __future__ import annotations
+
+import numpy as np
+from scipy.signal import welch
+from typing import Dict, Optional
+
+
+DISCLAIMER = (
+    "Brain age estimation is a research-grade wellness indicator based on spectral EEG features. "
+    "It is NOT a medical diagnosis. Individual variation is high. "
+    "Consult a healthcare professional for medical concerns."
+)
+
+# Population norms derived from Banville 2024 + literature
+# Aperiodic exponent decreases linearly with age
+# At age 20: ~2.3, at age 70: ~1.6 (approximate)
+_AGE_EXPONENT_SLOPE = -0.014   # exponent change per year
+_AGE_EXPONENT_INTERCEPT = 2.58  # expected exponent at age 0
+
+
+def _compute_aperiodic(signal: np.ndarray, fs: float = 256.0) -> Dict:
+    """Fast aperiodic exponent estimation via log-log PSD regression."""
+    nperseg = min(len(signal), int(fs * 4))
+    freqs, psd = welch(signal, fs=fs, nperseg=nperseg)
+
+    mask = (freqs >= 2) & (freqs <= 40)
+    if mask.sum() < 5:
+        return {"exponent": 2.0, "offset": 1.0, "r2": 0.0}
+
+    log_f = np.log10(freqs[mask])
+    log_p = np.log10(psd[mask] + 1e-30)
+    coeffs = np.polyfit(log_f, log_p, 1)
+    exponent = float(-coeffs[0])
+    offset = float(coeffs[1])
+
+    predicted = np.polyval(coeffs, log_f)
+    ss_res = np.sum((log_p - predicted) ** 2)
+    ss_tot = np.sum((log_p - log_p.mean()) ** 2)
+    r2 = float(np.clip(1 - ss_res / (ss_tot + 1e-10), 0, 1))
+
+    return {"exponent": exponent, "offset": offset, "r2": r2}
+
+
+class BrainAgeEstimator:
+    """Estimate biological brain age from 4-channel Muse 2 EEG.
+
+    Uses aperiodic 1/f features + band powers as age predictors.
+    The model uses population-level norms from Banville 2024.
+    A trained LightGBM model can be loaded from models/saved/ if available.
+    """
+
+    def __init__(self, model_path: Optional[str] = None):
+        self._lgbm = None
+        self._scaler = None
+        if model_path:
+            self._load_model(model_path)
+
+    def _load_model(self, path: str):
+        try:
+            import joblib
+            data = joblib.load(path)
+            self._lgbm = data.get("model")
+            self._scaler = data.get("scaler")
+        except Exception:
+            pass
+
+    def _extract_features(self, signals: np.ndarray, fs: float) -> np.ndarray:
+        """Extract age-predictive features per channel, then average."""
+        from processing.eeg_processor import preprocess, extract_band_powers
+
+        if signals.ndim == 1:
+            channels = [signals]
+        else:
+            channels = [signals[i] for i in range(signals.shape[0])]
+
+        all_features = []
+        for ch in channels:
+            processed = preprocess(ch, fs)
+            bands = extract_band_powers(processed, fs)
+            ap = _compute_aperiodic(processed, fs)
+
+            # Per-channel feature vector
+            feats = [
+                ap["exponent"],
+                ap["offset"],
+                ap["r2"],
+                bands.get("delta", 0.3),
+                bands.get("theta", 0.15),
+                bands.get("alpha", 0.20),
+                bands.get("beta", 0.15),
+                bands.get("high_beta", 0.05),
+                bands.get("gamma", 0.05),
+                bands.get("alpha", 0.20) / (bands.get("beta", 0.15) + 1e-10),
+                bands.get("theta", 0.15) / (bands.get("alpha", 0.20) + 1e-10),
+            ]
+            all_features.append(feats)
+
+        return np.mean(all_features, axis=0)
+
+    def predict(
+        self,
+        signals: np.ndarray,
+        fs: float = 256.0,
+        chronological_age: Optional[float] = None,
+    ) -> Dict:
+        """Estimate biological brain age from EEG.
+
+        Args:
+            signals: (n_channels, n_samples) or (n_samples,) EEG array
+            fs: sampling rate
+            chronological_age: user's actual age in years (for gap calculation)
+
+        Returns:
+            dict with predicted_age, brain_age_gap, percentile, confidence,
+            aperiodic features, and disclaimer.
+        """
+        feats = self._extract_features(signals, fs)
+        exponent = feats[0]
+
+        # Heuristic age prediction from aperiodic exponent (Banville 2024 norms)
+        # exponent = intercept + slope * age → age = (exponent - intercept) / slope
+        predicted_age = (_AGE_EXPONENT_INTERCEPT - exponent) / (-_AGE_EXPONENT_SLOPE)
+        predicted_age = float(np.clip(predicted_age, 15.0, 90.0))
+
+        # If trained model available, use it instead
+        if self._lgbm is not None:
+            try:
+                x = feats.reshape(1, -1)
+                if self._scaler is not None:
+                    x = self._scaler.transform(x)
+                predicted_age = float(self._lgbm.predict(x)[0])
+                predicted_age = float(np.clip(predicted_age, 15.0, 90.0))
+            except Exception:
+                pass
+
+        # Brain Age Gap
+        gap = None
+        gap_interpretation = None
+        if chronological_age is not None:
+            gap = round(predicted_age - chronological_age, 1)
+            if gap <= -5:
+                gap_interpretation = "Your brain appears younger than average for your age."
+            elif gap >= 5:
+                gap_interpretation = "Your brain appears older than average for your age."
+            else:
+                gap_interpretation = "Your brain age is within typical range for your age."
+
+        # Confidence based on fit quality
+        r2 = float(feats[2])
+        confidence = float(np.clip(0.3 + 0.5 * r2, 0.3, 0.8))
+
+        # Rough percentile (normal distribution, population SD ~8 years)
+        percentile = None
+        if chronological_age is not None and gap is not None:
+            from scipy.stats import norm
+            percentile = int(norm.cdf(gap, 0, 8) * 100)
+
+        return {
+            "predicted_age": round(predicted_age, 1),
+            "brain_age_gap": gap,
+            "gap_interpretation": gap_interpretation,
+            "percentile": percentile,
+            "confidence": round(confidence, 3),
+            "aperiodic_exponent": round(exponent, 3),
+            "aperiodic_offset": round(float(feats[1]), 3),
+            "aperiodic_r2": round(r2, 3),
+            "alpha_power": round(float(feats[5]), 4),
+            "beta_power": round(float(feats[6]), 4),
+            "delta_power": round(float(feats[3]), 4),
+            "disclaimer": DISCLAIMER,
+            "model_type": "aperiodic_heuristic" if self._lgbm is None else "lgbm",
+        }
+
+
+_instance: Optional[BrainAgeEstimator] = None
+
+
+def get_brain_age_estimator() -> BrainAgeEstimator:
+    global _instance
+    if _instance is None:
+        import os
+        model_path = os.path.join(
+            os.path.dirname(__file__), "saved", "brain_age_lgbm.pkl"
+        )
+        _instance = BrainAgeEstimator(model_path if os.path.exists(model_path) else None)
+    return _instance

--- a/ml/models/memory_consolidation_tracker.py
+++ b/ml/models/memory_consolidation_tracker.py
@@ -1,0 +1,277 @@
+"""Sleep Memory Consolidation Tracker via Spindle-SO Coupling.
+
+Tracks memory consolidation quality during sleep by measuring:
+1. Sleep spindle density (11-16 Hz bursts per minute) — from existing detector
+2. Slow oscillation (SO) detection (0.5-1.5 Hz, 1-4 Hz for Muse 2's limited bandwidth)
+3. SO-spindle coupling (phase-amplitude coupling proxy)
+4. Optional: TMR (targeted memory reactivation) up-state detection
+
+Scientific basis:
+- npj Science of Learning (2025): personalized TMR with SO-spindle sync enhances memory
+- bioRxiv (2025): forehead EEG (AF7/AF8) can reliably detect SO phase for closed-loop TMR
+- 15-25% increase in slow-wave activity with phase-locked cueing
+- Spindle density in N2/N3 predicts next-day memory performance (r=0.4-0.6)
+"""
+from __future__ import annotations
+
+import numpy as np
+from scipy.signal import butter, filtfilt, hilbert
+from typing import Dict, List, Optional
+
+
+def detect_slow_oscillations(
+    signal: np.ndarray, fs: float = 256.0
+) -> Dict:
+    """Detect slow oscillation (SO) events in EEG signal.
+
+    For Muse 2 with limited delta bandwidth, targets 0.5-2.0 Hz.
+    Returns SO events, up-state timestamps, and power.
+    """
+    # Bandpass 0.5–2.0 Hz for slow oscillations
+    nyq = fs / 2
+    low, high = 0.5 / nyq, min(2.0 / nyq, 0.99)
+    b, a = butter(2, [low, high], btype="band")
+    so_signal = filtfilt(b, a, signal)
+
+    # SO power
+    so_power = float(np.mean(so_signal ** 2))
+
+    # Detect up-states: positive zero-crossings of the filtered signal
+    # Up-state = transition from negative to positive half-cycle
+    zero_crossings = np.where(np.diff(np.sign(so_signal)) > 0)[0]
+
+    # Filter: amplitude must exceed threshold for valid SO
+    threshold = 30.0  # µV, relaxed for prefrontal sites (lower amplitude)
+    valid_upcross = []
+    for zc in zero_crossings:
+        window_start = max(0, zc - int(0.5 * fs))
+        window_end = min(len(so_signal), zc + int(0.5 * fs))
+        if np.ptp(so_signal[window_start:window_end]) > threshold:
+            valid_upcross.append(zc)
+
+    so_rate = len(valid_upcross) / (len(signal) / fs / 60.0 + 1e-6)  # per minute
+
+    return {
+        "so_power": round(so_power, 6),
+        "so_count": len(valid_upcross),
+        "so_rate_per_min": round(so_rate, 2),
+        "up_state_indices": valid_upcross[:50],  # cap for API response
+        "so_signal": so_signal,  # for coupling computation
+    }
+
+
+def compute_spindle_so_coupling(
+    signal: np.ndarray,
+    fs: float = 256.0,
+    so_result: Optional[Dict] = None,
+) -> float:
+    """Compute SO-spindle coupling strength (phase-amplitude coupling proxy).
+
+    Returns coupling score 0-1. Higher = stronger spindle activity
+    locked to SO up-states.
+    """
+    if so_result is None:
+        so_result = detect_slow_oscillations(signal, fs)
+
+    up_states = so_result.get("up_state_indices", [])
+    if len(up_states) < 3:
+        return 0.0
+
+    # Spindle band power (11-16 Hz)
+    nyq = fs / 2
+    b, a = butter(4, [11 / nyq, 16 / nyq], btype="band")
+    spindle_signal = filtfilt(b, a, signal)
+    spindle_env = np.abs(hilbert(spindle_signal))
+
+    # Sample spindle envelope at SO up-states and nearby times
+    window = int(0.5 * fs)  # 500ms window around up-state
+    up_envelope = []
+    for idx in up_states[:30]:
+        start = max(0, idx - window // 2)
+        end = min(len(spindle_env), idx + window // 2)
+        up_envelope.append(float(np.mean(spindle_env[start:end])))
+
+    # Compare to baseline envelope
+    baseline_env = float(np.mean(spindle_env))
+    if baseline_env < 1e-10:
+        return 0.0
+
+    mean_up_env = float(np.mean(up_envelope))
+    coupling = float(np.clip((mean_up_env - baseline_env) / (baseline_env + 1e-10), 0, 1))
+    return coupling
+
+
+class MemoryConsolidationTracker:
+    """Track memory consolidation quality during sleep via spindle-SO coupling.
+
+    Score per epoch (30 seconds) and aggregate across a sleep session.
+    """
+
+    def __init__(self):
+        self._epoch_scores: List[Dict] = []
+
+    def score_epoch(
+        self,
+        signals: np.ndarray,
+        fs: float = 256.0,
+        sleep_stage: str = "N2",
+    ) -> Dict:
+        """Score a single sleep epoch for memory consolidation quality.
+
+        Args:
+            signals: (n_channels, n_samples) or (n_samples,) array
+            fs: sampling rate
+            sleep_stage: current sleep stage (N2/N3 most relevant)
+
+        Returns:
+            dict with consolidation_quality (0-1), spindle_density,
+            coupling_strength, so_rate, and sleep_stage.
+        """
+        from processing.eeg_processor import detect_sleep_spindles, preprocess
+
+        # Use frontal channel (AF7 or ch1 for Muse 2)
+        if signals.ndim == 2 and signals.shape[0] >= 2:
+            frontal = signals[1]  # AF7
+        elif signals.ndim == 2:
+            frontal = signals[0]
+        else:
+            frontal = signals
+
+        processed = preprocess(frontal, fs)
+        epoch_duration_min = len(processed) / fs / 60.0
+
+        # Spindle detection (existing function)
+        try:
+            spindle_result = detect_sleep_spindles(processed, fs)
+            spindle_count = spindle_result.get("spindle_count", 0)
+        except Exception:
+            spindle_count = 0
+
+        spindle_density = spindle_count / (epoch_duration_min + 1e-6)  # per minute
+
+        # Slow oscillation detection
+        so_result = detect_slow_oscillations(processed, fs)
+
+        # SO-spindle coupling
+        coupling = compute_spindle_so_coupling(processed, fs, so_result)
+
+        # Sleep stage weight: N3 > N2 >> N1 > REM > Wake
+        stage_upper = sleep_stage.upper()
+        stage_weight = {
+            "N3": 1.0, "N2": 0.8, "N1": 0.3, "REM": 0.4, "WAKE": 0.1
+        }.get(stage_upper, 0.5)
+
+        # Consolidation quality score
+        # Normalize spindle density: >3/min is excellent for N2/N3
+        spindle_score = float(np.clip(spindle_density / 4.0, 0, 1))
+        coupling_score = float(np.clip(coupling * 2, 0, 1))
+        so_score = float(np.clip(so_result["so_rate_per_min"] / 3.0, 0, 1))
+
+        quality = stage_weight * (
+            0.40 * spindle_score
+            + 0.35 * coupling_score
+            + 0.25 * so_score
+        )
+        quality = float(np.clip(quality, 0.0, 1.0))
+
+        epoch_score = {
+            "consolidation_quality": round(quality, 4),
+            "spindle_density_per_min": round(spindle_density, 2),
+            "spindle_count": int(spindle_count),
+            "coupling_strength": round(coupling, 3),
+            "so_rate_per_min": round(so_result["so_rate_per_min"], 2),
+            "so_count": int(so_result["so_count"]),
+            "sleep_stage": sleep_stage,
+            "stage_weight": round(stage_weight, 2),
+            "model_type": "spindle_so_coupling",
+        }
+        self._epoch_scores.append(epoch_score)
+        return epoch_score
+
+    def score_session(self, epoch_scores: Optional[List[Dict]] = None) -> Dict:
+        """Aggregate memory consolidation across a full sleep session.
+
+        Uses weighted average (N3 > N2 >> other stages).
+        """
+        scores = epoch_scores or self._epoch_scores
+        if not scores:
+            return {
+                "session_quality": 0.0,
+                "mean_spindle_density": 0.0,
+                "mean_coupling": 0.0,
+                "n_epochs": 0,
+                "message": "No epochs scored yet",
+            }
+
+        weights = [s.get("stage_weight", 0.5) for s in scores]
+        qualities = [s.get("consolidation_quality", 0.0) for s in scores]
+        spindle_densities = [s.get("spindle_density_per_min", 0.0) for s in scores]
+        couplings = [s.get("coupling_strength", 0.0) for s in scores]
+
+        total_weight = sum(weights) + 1e-10
+        session_quality = sum(w * q for w, q in zip(weights, qualities)) / total_weight
+
+        if session_quality >= 0.65:
+            quality_label = "excellent"
+            message = "Strong memory consolidation activity detected."
+        elif session_quality >= 0.45:
+            quality_label = "good"
+            message = "Moderate memory consolidation activity."
+        elif session_quality >= 0.25:
+            quality_label = "fair"
+            message = "Below-average memory consolidation. More slow-wave sleep may help."
+        else:
+            quality_label = "poor"
+            message = "Low memory consolidation activity. Consider sleep hygiene improvements."
+
+        return {
+            "session_quality": round(float(session_quality), 4),
+            "quality_label": quality_label,
+            "mean_spindle_density": round(float(np.mean(spindle_densities)), 2),
+            "mean_coupling": round(float(np.mean(couplings)), 3),
+            "n_epochs": len(scores),
+            "n2_n3_epochs": sum(1 for s in scores if s.get("sleep_stage") in ("N2", "N3")),
+            "message": message,
+        }
+
+    def get_tmr_trigger(
+        self, signals: np.ndarray, fs: float = 256.0, sleep_stage: str = "N2"
+    ) -> Dict:
+        """Check if current SO phase is appropriate for TMR audio cue.
+
+        Returns True if we are near an SO up-state (good time to play sound).
+        For real-time TMR implementation.
+        """
+        if signals.ndim == 2 and signals.shape[0] >= 2:
+            frontal = signals[1]
+        elif signals.ndim == 2:
+            frontal = signals[0]
+        else:
+            frontal = signals
+
+        from processing.eeg_processor import preprocess
+        processed = preprocess(frontal, fs)
+        so = detect_slow_oscillations(processed, fs)
+
+        up_states = so.get("up_state_indices", [])
+        last_sample = len(processed) - 1
+
+        # Check if we just crossed an up-state (within last 200ms)
+        recent_threshold = int(0.2 * fs)
+        in_upstate = any(abs(last_sample - u) < recent_threshold for u in up_states)
+
+        return {
+            "trigger_cue": bool(in_upstate and sleep_stage in ("N2", "N3")),
+            "sleep_stage": sleep_stage,
+            "so_count": so["so_count"],
+            "near_upstate": in_upstate,
+        }
+
+
+_tracker_instances: dict = {}
+
+
+def get_memory_tracker(user_id: str = "default") -> MemoryConsolidationTracker:
+    if user_id not in _tracker_instances:
+        _tracker_instances[user_id] = MemoryConsolidationTracker()
+    return _tracker_instances[user_id]

--- a/ml/tests/test_brain_age_sleep.py
+++ b/ml/tests/test_brain_age_sleep.py
@@ -1,0 +1,101 @@
+"""Tests for BrainAgeEstimator and MemoryConsolidationTracker."""
+import sys
+import os
+import numpy as np
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from models.brain_age_estimator import BrainAgeEstimator, DISCLAIMER as BRAIN_AGE_DISCLAIMER
+from models.memory_consolidation_tracker import MemoryConsolidationTracker
+
+
+# ── Brain Age ────────────────────────────────────────────────────────────────
+
+def test_brain_age_output_keys():
+    rng = np.random.default_rng(42)
+    eeg = rng.normal(0, 10, (4, 1024)).astype(np.float32)
+    estimator = BrainAgeEstimator()
+    result = estimator.predict(eeg, fs=256)
+    assert "predicted_age" in result
+    assert "brain_age_gap" in result  # None when no chronological_age
+    assert "aperiodic_exponent" in result
+    assert "disclaimer" in result
+    assert result["disclaimer"] == BRAIN_AGE_DISCLAIMER
+
+
+def test_brain_age_range():
+    rng = np.random.default_rng(1)
+    eeg = rng.normal(0, 10, (4, 2048)).astype(np.float32)
+    estimator = BrainAgeEstimator()
+    result = estimator.predict(eeg, fs=256)
+    assert 15 <= result["predicted_age"] <= 90
+
+
+def test_brain_age_gap_computed():
+    rng = np.random.default_rng(2)
+    eeg = rng.normal(0, 10, (4, 2048)).astype(np.float32)
+    estimator = BrainAgeEstimator()
+    result = estimator.predict(eeg, fs=256, chronological_age=30.0)
+    assert result["brain_age_gap"] is not None
+    assert result["gap_interpretation"] is not None
+    assert result["percentile"] is not None
+
+
+def test_brain_age_single_channel():
+    rng = np.random.default_rng(3)
+    eeg = rng.normal(0, 10, 1024).astype(np.float32)
+    estimator = BrainAgeEstimator()
+    result = estimator.predict(eeg, fs=256)
+    assert 15 <= result["predicted_age"] <= 90
+
+
+# ── Memory Consolidation ─────────────────────────────────────────────────────
+
+def test_epoch_score_keys():
+    rng = np.random.default_rng(42)
+    eeg = rng.normal(0, 20, (4, 7680)).astype(np.float32)  # 30 sec at 256 Hz
+    tracker = MemoryConsolidationTracker()
+    result = tracker.score_epoch(eeg, fs=256, sleep_stage="N2")
+    assert "consolidation_quality" in result
+    assert "spindle_density_per_min" in result
+    assert "coupling_strength" in result
+    assert "so_rate_per_min" in result
+    assert 0.0 <= result["consolidation_quality"] <= 1.0
+
+
+def test_epoch_score_range():
+    rng = np.random.default_rng(2)
+    eeg = rng.normal(0, 15, (4, 7680)).astype(np.float32)
+    tracker = MemoryConsolidationTracker()
+    result = tracker.score_epoch(eeg, fs=256, sleep_stage="N3")
+    assert 0.0 <= result["consolidation_quality"] <= 1.0
+    assert result["spindle_density_per_min"] >= 0
+    assert 0.0 <= result["coupling_strength"] <= 1.0
+
+
+def test_session_summary():
+    rng = np.random.default_rng(5)
+    tracker = MemoryConsolidationTracker()
+    for _ in range(3):
+        eeg = rng.normal(0, 15, (4, 7680)).astype(np.float32)
+        tracker.score_epoch(eeg, fs=256, sleep_stage="N2")
+    summary = tracker.score_session()
+    assert "session_quality" in summary
+    assert "quality_label" in summary
+    assert summary["n_epochs"] == 3
+    assert 0.0 <= summary["session_quality"] <= 1.0
+
+
+def test_session_empty():
+    tracker = MemoryConsolidationTracker()
+    summary = tracker.score_session()
+    assert summary["n_epochs"] == 0
+    assert summary["session_quality"] == 0.0
+
+
+def test_tmr_trigger():
+    rng = np.random.default_rng(6)
+    eeg = rng.normal(0, 20, (4, 512)).astype(np.float32)
+    tracker = MemoryConsolidationTracker()
+    result = tracker.get_tmr_trigger(eeg, fs=256, sleep_stage="N2")
+    assert "trigger_cue" in result
+    assert isinstance(result["trigger_cue"], bool)


### PR DESCRIPTION
## Summary
- **#59**: New `BrainAgeEstimator` using aperiodic 1/f spectral features (aperiodic exponent + band powers). Based on Banville 2024 (Muse S, R²=0.3-0.5). Outputs `predicted_age`, `brain_age_gap`, `percentile`. Falls back to heuristic when no trained model is saved. Includes clear `DISCLAIMER` — wellness indicator, not a medical diagnosis.
- **#62**: New `MemoryConsolidationTracker` measuring spindle-SO coupling during sleep. Detects slow oscillations (0.5-2.0 Hz) and computes phase-amplitude coupling against the existing spindle detector. Per-epoch and session-level quality scores with stage weighting (N3 > N2 >> N1/REM). Includes TMR up-state detection for audio cueing.

## New API endpoints (cognitive router)
- `POST /brain-age` — brain age estimation with optional chronological age for gap
- `POST /sleep/memory-consolidation/epoch` — score a 30s sleep epoch
- `GET  /sleep/memory-consolidation/session/{user_id}` — session summary
- `POST /sleep/memory-consolidation/tmr-check` — check if near SO up-state for TMR cue

## Test plan
- [x] `test_brain_age_output_keys` — all output keys present, disclaimer matches
- [x] `test_brain_age_range` — predicted age clamped to [15, 90]
- [x] `test_brain_age_gap_computed` — gap, interpretation, percentile when chronological_age provided
- [x] `test_brain_age_single_channel` — works with 1D input
- [x] `test_epoch_score_keys` — all consolidation keys present, quality in [0, 1]
- [x] `test_epoch_score_range` — quality, spindle_density, coupling all in range
- [x] `test_session_summary` — aggregation correct, n_epochs counts properly
- [x] `test_session_empty` — empty tracker returns zero quality, zero epochs
- [x] `test_tmr_trigger` — returns bool trigger_cue
- [x] Ruff lint clean