### PR TITLE
feat: emotional granularity via VAD + 27-emotion mapping (#63)

### DIFF
--- a/ml/api/routes/cognitive.py
+++ b/ml/api/routes/cognitive.py
@@ -259,6 +259,38 @@ async def record_flexibility_baseline(data: EEGInput):
     return detector.record_baseline(signals, data.fs)
 
 
+
+# ── Emotional Granularity ────────────────────────────────────────────────────
+
+from models.emotion_granularity import get_granularity_mapper, estimate_dominance as _estimate_dominance
+
+
+@router.post("/emotion-granularity")
+async def analyze_emotion_granularity(data: EEGInput):
+    """Map EEG-derived VAD coordinates to 27-emotion nuanced vocabulary.
+
+    Returns primary emotion + 2 nuance emotions with narrative description.
+    Computes valence and arousal from EEG band powers, then maps to the
+    27-emotion VAD space with dominance estimation.
+    """
+    from processing.eeg_processor import preprocess, extract_band_powers
+
+    signals = np.array(data.signals)
+    if signals.ndim == 1:
+        signals = signals.reshape(1, -1)
+    ch = signals[0]
+
+    bands = extract_band_powers(preprocess(ch, data.fs), data.fs)
+    alpha = max(bands.get("alpha", 0.2), 1e-10)
+    beta = max(bands.get("beta", 0.15), 1e-10)
+
+    valence = float(np.clip(np.tanh((alpha / beta - 0.7) * 2.0), -1, 1))
+    arousal = float(np.clip(beta / (beta + alpha), 0, 1))
+    dominance = _estimate_dominance(bands)
+
+    mapper = get_granularity_mapper()
+    result = mapper.map(valence, arousal, dominance)
+    return _numpy_safe(result)
 @router.post("/voice-cognitive-load")
 async def voice_cognitive_load(request: dict):
     """Estimate cognitive load from voice prosodic features.

--- a/ml/models/emotion_granularity.py
+++ b/ml/models/emotion_granularity.py
@@ -1,0 +1,232 @@
+"""Emotional Granularity via VAD Regression + 27-emotion mapping.
+
+Expands EEG emotion output from 6 basic emotions to 27 nuanced affect states
+by mapping continuous VAD (Valence-Arousal-Dominance) coordinates to a
+comprehensive emotion vocabulary.
+
+Scientific basis:
+- IEEE (2025): EEGEmotions-27 dataset — 62.24% accuracy on 27 categories
+- MDPI Mathematics (2025): EEG-RegNet, 95% DEAP via VAD regression
+- Dominance (sense of control/agency) adds crucial third dimension
+- VAD coordinates from Russell's Circumplex + dimensional emotion theory
+
+Usage:
+    from models.emotion_granularity import EmotionGranularityMapper, estimate_dominance
+
+    dominance = estimate_dominance(band_powers)
+    mapper = EmotionGranularityMapper()
+    result = mapper.map(valence=0.3, arousal=0.7, dominance=0.6)
+"""
+from __future__ import annotations
+
+from typing import Dict, Optional, Tuple
+
+import numpy as np
+
+
+# VAD coordinates for 27 emotion categories
+# Format: (valence, arousal, dominance) — all in [-1,1] or [0,1] depending on dimension
+# Valence: -1 (very negative) to +1 (very positive)
+# Arousal: 0 (very calm) to 1 (very energetic)
+# Dominance: 0 (submissive/overwhelmed) to 1 (dominant/in-control)
+EMOTION_VAD_MAP: Dict[str, Tuple[float, float, float]] = {
+    # Positive high-arousal
+    "excited":      (0.80,  0.90, 0.65),
+    "happy":        (0.85,  0.65, 0.70),
+    "elated":       (0.90,  0.85, 0.75),
+    "enthusiastic": (0.75,  0.80, 0.65),
+    "awe":          (0.60,  0.75, 0.30),
+    "surprised":    (0.30,  0.80, 0.35),
+
+    # Positive low-arousal
+    "content":      (0.70,  0.20, 0.60),
+    "calm":         (0.50,  0.10, 0.55),
+    "serene":       (0.65,  0.08, 0.50),
+    "nostalgic":    (0.30,  0.20, 0.35),
+    "grateful":     (0.75,  0.30, 0.55),
+
+    # Neutral
+    "neutral":      (0.00,  0.20, 0.50),
+    "bored":        (-0.20, 0.10, 0.30),
+    "pensive":      (0.10,  0.15, 0.40),
+
+    # Negative high-arousal
+    "angry":        (-0.70, 0.85, 0.75),
+    "fearful":      (-0.75, 0.85, 0.10),
+    "anxious":      (-0.55, 0.80, 0.15),
+    "frustrated":   (-0.60, 0.70, 0.50),
+    "stressed":     (-0.50, 0.75, 0.25),
+    "disgusted":    (-0.65, 0.55, 0.60),
+
+    # Negative low-arousal
+    "sad":          (-0.75, 0.15, 0.20),
+    "melancholy":   (-0.40, 0.20, 0.35),
+    "lonely":       (-0.50, 0.15, 0.15),
+    "ashamed":      (-0.60, 0.35, 0.10),
+    "hopeless":     (-0.80, 0.10, 0.05),
+
+    # High dominance special
+    "proud":        (0.70,  0.50, 0.90),
+    "contemptuous": (-0.40, 0.45, 0.80),
+}
+
+
+def estimate_dominance(band_powers: Dict[str, float]) -> float:
+    """Estimate dominance (sense of control/agency) from frontal band powers.
+
+    High beta + low theta at frontal = high dominance (in control, assertive).
+    High theta + low beta = low dominance (overwhelmed, submissive).
+
+    Args:
+        band_powers: Dict from extract_band_powers() — delta, theta, alpha, beta, etc.
+
+    Returns:
+        dominance in [0, 1]
+    """
+    alpha = max(band_powers.get("alpha", 0.2), 1e-10)
+    beta = max(band_powers.get("beta", 0.15), 1e-10)
+    theta = max(band_powers.get("theta", 0.15), 1e-10)
+    high_beta = max(band_powers.get("high_beta", 0.05), 1e-10)
+
+    eps = 1e-10
+    theta_beta_ratio = theta / (beta + eps)
+
+    # Dominance from beta/alpha ratio (high beta = assertive engagement)
+    beta_alpha_component = float(np.tanh((beta / (alpha + eps) - 0.5) * 2.0)) * 0.5 + 0.5
+
+    # Dominance from theta/beta (inverse — high theta = overwhelmed)
+    theta_beta_component = float(np.clip(1.0 - theta_beta_ratio * 0.8, 0, 1))
+
+    # High-beta penalty for anxiety (reduces perceived dominance)
+    anxiety_penalty = float(np.clip(high_beta / (beta + eps) - 0.3, 0, 0.4))
+
+    dominance = float(np.clip(
+        0.50 * beta_alpha_component
+        + 0.50 * theta_beta_component
+        - anxiety_penalty,
+        0.0, 1.0
+    ))
+    return dominance
+
+
+def _vad_distance(
+    valence: float, arousal: float, dominance: float,
+    ev: float, ea: float, ed: float,
+    weights: Tuple[float, float, float] = (0.45, 0.35, 0.20),
+) -> float:
+    """Weighted Euclidean distance in VAD space."""
+    wv, wa, wd = weights
+    return float(np.sqrt(
+        wv * (valence - ev) ** 2
+        + wa * (arousal - ea) ** 2
+        + wd * (dominance - ed) ** 2
+    ))
+
+
+class EmotionGranularityMapper:
+    """Maps VAD coordinates to nuanced emotion vocabulary.
+
+    Finds top-N closest emotions in VAD space and returns them as
+    a nuanced affect description.
+    """
+
+    def __init__(self, vad_map: Optional[Dict] = None):
+        self._map = vad_map or EMOTION_VAD_MAP
+
+    def map(
+        self,
+        valence: float,
+        arousal: float,
+        dominance: float = 0.5,
+        top_n: int = 3,
+    ) -> Dict:
+        """Map VAD coordinates to nuanced emotion labels.
+
+        Args:
+            valence: -1 (very negative) to +1 (very positive)
+            arousal: 0 (calm) to 1 (energetic)
+            dominance: 0 (overwhelmed) to 1 (in control)
+            top_n: number of top emotions to return
+
+        Returns:
+            dict with primary_emotion, nuance_emotions, narrative, vad, all_scores
+        """
+        # Compute distances to all VAD points
+        scores = {}
+        for emotion, (ev, ea, ed) in self._map.items():
+            dist = _vad_distance(valence, arousal, dominance, ev, ea, ed)
+            scores[emotion] = float(1.0 / (dist + 0.1))  # inverse distance = similarity
+
+        # Sort by similarity
+        sorted_emotions = sorted(scores.items(), key=lambda x: -x[1])
+        top_emotions = sorted_emotions[:top_n]
+
+        primary = top_emotions[0][0]
+        nuances = [e for e, _ in top_emotions[1:]]
+
+        # Normalize scores to probabilities
+        total = sum(s for _, s in top_emotions)
+        top_probs = {e: round(s / total, 3) for e, s in top_emotions}
+
+        # Build narrative
+        if len(nuances) >= 2:
+            narrative = f"Mostly {primary}, with hints of {nuances[0]} and {nuances[1]}."
+        elif len(nuances) == 1:
+            narrative = f"Primarily {primary}, with undertones of {nuances[0]}."
+        else:
+            narrative = f"Predominantly {primary}."
+
+        # VAD zone label
+        zone = _get_vad_zone(valence, arousal, dominance)
+
+        return {
+            "primary_emotion": primary,
+            "nuance_emotions": nuances,
+            "narrative": narrative,
+            "affect_zone": zone,
+            "top_emotions": top_probs,
+            "valence": round(float(valence), 3),
+            "arousal": round(float(arousal), 3),
+            "dominance": round(float(dominance), 3),
+            "model_type": "vad_granularity_27",
+        }
+
+    def map_from_basic(
+        self,
+        basic_emotion: str,
+        valence: float,
+        arousal: float,
+        band_powers: Optional[Dict] = None,
+        top_n: int = 3,
+    ) -> Dict:
+        """Convenience: map from existing 6-class output + computed VAD.
+
+        Args:
+            basic_emotion: one of happy/sad/angry/fear/surprise/neutral
+            valence: from emotion classifier
+            arousal: from emotion classifier
+            band_powers: optional, used to estimate dominance
+            top_n: number of top emotions
+        """
+        dominance = 0.5
+        if band_powers:
+            dominance = estimate_dominance(band_powers)
+        return self.map(valence, arousal, dominance, top_n)
+
+
+def _get_vad_zone(valence: float, arousal: float, dominance: float) -> str:
+    """Label the VAD octant / quadrant for easy interpretation."""
+    v = "positive" if valence >= 0 else "negative"
+    a = "high-energy" if arousal >= 0.5 else "low-energy"
+    d = "in-control" if dominance >= 0.5 else "overwhelmed"
+    return f"{v}, {a}, {d}"
+
+
+_mapper_instance: Optional[EmotionGranularityMapper] = None
+
+
+def get_granularity_mapper() -> EmotionGranularityMapper:
+    global _mapper_instance
+    if _mapper_instance is None:
+        _mapper_instance = EmotionGranularityMapper()
+    return _mapper_instance

--- a/ml/tests/test_emotion_granularity.py
+++ b/ml/tests/test_emotion_granularity.py
@@ -1,0 +1,88 @@
+"""Tests for EmotionGranularityMapper and estimate_dominance."""
+import os
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from models.emotion_granularity import (
+    EMOTION_VAD_MAP,
+    EmotionGranularityMapper,
+    estimate_dominance,
+)
+
+
+def test_map_output_keys():
+    mapper = EmotionGranularityMapper()
+    result = mapper.map(valence=0.5, arousal=0.7, dominance=0.6)
+    assert "primary_emotion" in result
+    assert "nuance_emotions" in result
+    assert "narrative" in result
+    assert "affect_zone" in result
+    assert "top_emotions" in result
+    assert "valence" in result
+    assert "arousal" in result
+    assert "dominance" in result
+
+
+def test_primary_emotion_is_valid():
+    mapper = EmotionGranularityMapper()
+    result = mapper.map(valence=0.8, arousal=0.8, dominance=0.7)
+    assert result["primary_emotion"] in EMOTION_VAD_MAP
+
+
+def test_happy_region():
+    mapper = EmotionGranularityMapper()
+    result = mapper.map(valence=0.85, arousal=0.65, dominance=0.70)
+    # Happy or elated should be top
+    assert result["primary_emotion"] in {"happy", "elated", "excited", "enthusiastic"}
+
+
+def test_sad_region():
+    mapper = EmotionGranularityMapper()
+    result = mapper.map(valence=-0.75, arousal=0.15, dominance=0.20)
+    assert result["primary_emotion"] in {"sad", "melancholy", "hopeless", "lonely"}
+
+
+def test_angry_region():
+    mapper = EmotionGranularityMapper()
+    result = mapper.map(valence=-0.70, arousal=0.85, dominance=0.75)
+    assert result["primary_emotion"] in {"angry", "frustrated", "stressed"}
+
+
+def test_nuance_count():
+    mapper = EmotionGranularityMapper()
+    result = mapper.map(valence=0.2, arousal=0.4, dominance=0.5, top_n=3)
+    assert len(result["nuance_emotions"]) == 2  # top_n - 1
+
+
+def test_narrative_contains_primary():
+    mapper = EmotionGranularityMapper()
+    result = mapper.map(valence=0.5, arousal=0.3, dominance=0.6)
+    assert result["primary_emotion"] in result["narrative"]
+
+
+def test_dominance_estimate_range():
+    rng = np.random.default_rng(42)
+    bands = {
+        "alpha": float(rng.uniform(0.1, 0.4)),
+        "beta": float(rng.uniform(0.1, 0.3)),
+        "theta": float(rng.uniform(0.05, 0.2)),
+        "high_beta": float(rng.uniform(0.02, 0.1)),
+    }
+    dom = estimate_dominance(bands)
+    assert 0.0 <= dom <= 1.0
+
+
+def test_map_from_basic():
+    mapper = EmotionGranularityMapper()
+    result = mapper.map_from_basic("happy", valence=0.7, arousal=0.6)
+    assert "primary_emotion" in result
+    assert result["primary_emotion"] in EMOTION_VAD_MAP
+
+
+def test_top_emotions_sum_to_one():
+    mapper = EmotionGranularityMapper()
+    result = mapper.map(valence=0.0, arousal=0.5, dominance=0.5, top_n=3)
+    total = sum(result["top_emotions"].values())
+    assert abs(total - 1.0) < 0.01


### PR DESCRIPTION
## Summary
- **#63**: New `EmotionGranularityMapper` that maps VAD (Valence-Arousal-Dominance) coordinates to 27 nuanced emotion labels from IEEE EEGEmotions-27 research.
- Adds `estimate_dominance()` from frontal band powers (beta/alpha ratio + inverse theta/beta).
- Outputs "primary emotion + 2 nuances" with human-readable narrative (e.g., "Mostly calm, with hints of nostalgic and serene").
- New `POST /emotion-granularity` endpoint integrates with existing EEG analysis pipeline via `EEGInput`.

## Test plan
- [x] `test_emotion_granularity.py` — output keys, valid emotions, regional mapping (happy/sad/angry), narrative, dominance range, top-N probabilities sum to 1
- [x] Ruff lint passes (all checks pass)
- [x] 10/10 tests pass