### PR TITLE
feat: add cognitive reserve estimation from EEG biomarkers (#125)

### DIFF
--- a/ml/api/routes/__init__.py
+++ b/ml/api/routes/__init__.py
@@ -74,6 +74,7 @@ from .auth_biometric import router as _auth_biometric
 from .gru_sleep import router as _gru_sleep
 from .seizure import router as _seizure
 from .emo_adapt import router as _emo_adapt
+from .cognitive_reserve import router as _cognitive_reserve
 
 router = APIRouter()
 
@@ -118,3 +119,4 @@ router.include_router(_auth_biometric)
 router.include_router(_gru_sleep)
 router.include_router(_seizure)
 router.include_router(_emo_adapt)
+router.include_router(_cognitive_reserve)

--- a/ml/api/routes/cognitive_reserve.py
+++ b/ml/api/routes/cognitive_reserve.py
@@ -1,0 +1,113 @@
+"""Cognitive reserve estimation API endpoints.
+
+Endpoints:
+    POST /cognitive-reserve/analyze         — analyze EEG epoch → reserve biomarkers
+    POST /cognitive-reserve/update-history  — append a score to longitudinal history
+    GET  /cognitive-reserve/trend           — get longitudinal trend
+    POST /cognitive-reserve/reset           — reset longitudinal history
+
+GitHub issue: #125 (EEG Biomarkers for Cognitive Reserve Estimation in Aging)
+"""
+
+from typing import List, Optional
+
+import numpy as np
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+router = APIRouter(tags=["Cognitive Reserve"])
+
+
+# ── Request / response models ─────────────────────────────────────────────────
+
+class CognitiveReserveAnalyzeRequest(BaseModel):
+    eeg_data: List[List[float]] = Field(
+        ...,
+        description="EEG data as [[ch0_samples...], [ch1_samples...]] "
+                    "or [[single_channel_samples...]]",
+    )
+    fs: float = Field(default=256.0, gt=0, description="Sampling rate in Hz")
+
+
+class UpdateHistoryRequest(BaseModel):
+    score: float = Field(..., ge=0.0, le=100.0, description="Reserve score (0-100)")
+
+
+class TrendRequest(BaseModel):
+    n_sessions: Optional[int] = Field(
+        default=None, gt=0,
+        description="Limit trend to the last n sessions. Omit to use all history.",
+    )
+
+
+# ── Endpoints ─────────────────────────────────────────────────────────────────
+
+@router.post("/cognitive-reserve/analyze")
+async def analyze_cognitive_reserve(request: CognitiveReserveAnalyzeRequest):
+    """Estimate cognitive reserve from an EEG epoch.
+
+    Computes four spectral biomarkers:
+    - Alpha peak frequency (8-13 Hz): higher = more reserve
+    - Aperiodic 1/f slope: flatter (less negative) = more reserve
+    - Theta/alpha ratio: lower = more reserve
+    - Brain age index: 0=young brain, 1=aged brain
+
+    Returns reserve_score (0-100), brain_age_index, alpha_peak_freq,
+    aperiodic_slope, theta_alpha_ratio, reserve_category, and a biomarkers
+    sub-dict with all numeric values.
+    """
+    try:
+        from models.cognitive_reserve_estimator import get_cognitive_reserve_estimator
+        estimator = get_cognitive_reserve_estimator()
+        eeg = np.array(request.eeg_data, dtype=np.float64)
+        result = estimator.predict(eeg, fs=request.fs)
+        return result
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@router.post("/cognitive-reserve/update-history")
+async def update_cognitive_reserve_history(request: UpdateHistoryRequest):
+    """Append a reserve score to the longitudinal session history.
+
+    Call after each session's analyze result to build a trend over time.
+    """
+    try:
+        from models.cognitive_reserve_estimator import get_cognitive_reserve_estimator
+        estimator = get_cognitive_reserve_estimator()
+        estimator.update_history(request.score)
+        return {"status": "ok", "score_added": request.score}
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@router.get("/cognitive-reserve/trend")
+async def get_cognitive_reserve_trend(n_sessions: Optional[int] = None):
+    """Get longitudinal cognitive reserve trend.
+
+    Returns slope_per_session (points/session), trend ("improving" | "stable" |
+    "declining"), and n_sessions (number of data points used).
+
+    Requires at least 2 scores in history for a meaningful trend.
+    """
+    try:
+        from models.cognitive_reserve_estimator import get_cognitive_reserve_estimator
+        estimator = get_cognitive_reserve_estimator()
+        return estimator.get_longitudinal_trend(n_sessions=n_sessions)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@router.post("/cognitive-reserve/reset")
+async def reset_cognitive_reserve():
+    """Reset the longitudinal score history.
+
+    Does not affect the underlying model — only clears stored session scores.
+    """
+    try:
+        from models.cognitive_reserve_estimator import get_cognitive_reserve_estimator
+        estimator = get_cognitive_reserve_estimator()
+        estimator.reset()
+        return {"status": "ok", "message": "Cognitive reserve history cleared."}
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/ml/models/cognitive_reserve_estimator.py
+++ b/ml/models/cognitive_reserve_estimator.py
@@ -1,0 +1,301 @@
+"""Cognitive reserve estimator from EEG spectral biomarkers.
+
+Estimates brain resilience and cognitive reserve using spectral biomarkers:
+- Alpha peak frequency (APF): dominant frequency in 8-13 Hz band
+- Aperiodic (1/f) slope: flatter slope = more cognitive reserve
+- Theta/alpha ratio: higher = less reserve
+- Brain age index: spectral proxy for brain age (higher delta/theta, lower alpha = older)
+
+References:
+    Stern (2009) — Cognitive reserve theory
+    Scally et al. (2018) — EEG spectral measures of cognitive reserve
+    Cesnaite et al. (2023) — Individual alpha frequency and cognitive reserve
+    Voytek et al. (2015) — Age-related changes in 1/f aperiodic slope
+"""
+from __future__ import annotations
+
+import threading
+from typing import Dict, List, Optional
+
+import numpy as np
+from scipy import signal as scipy_signal
+
+
+class CognitiveReserveEstimator:
+    """Estimate cognitive reserve from EEG spectral biomarkers.
+
+    Uses alpha peak frequency, aperiodic 1/f slope, theta/alpha ratio,
+    and a brain age index derived from band power ratios.
+
+    Usage:
+        estimator = CognitiveReserveEstimator()
+        result = estimator.predict(eeg_array, fs=256)
+        # result['reserve_score'] in [0, 100]
+    """
+
+    VALID_CATEGORIES = ("low", "moderate", "high")
+
+    def __init__(self, fs: float = 256.0) -> None:
+        self._default_fs = fs
+        self._score_history: List[float] = []
+        self._lock = threading.Lock()
+
+    # ── Public API ────────────────────────────────────────────────────────────
+
+    def predict(self, eeg: np.ndarray, fs: float = 256.0) -> Dict:
+        """Estimate cognitive reserve from a single EEG epoch.
+
+        Args:
+            eeg: (n_channels, n_samples) or (n_samples,) float array, µV.
+            fs: Sampling rate in Hz.
+
+        Returns:
+            dict with keys:
+                reserve_score      float  0-100  overall cognitive reserve
+                brain_age_index    float  0-1    0=young brain, 1=aged brain
+                alpha_peak_freq    float  Hz     dominant alpha frequency
+                aperiodic_slope    float         1/f slope (negative; flatter = more reserve)
+                theta_alpha_ratio  float         higher = less reserve
+                reserve_category   str           "low" | "moderate" | "high"
+                biomarkers         dict          sub-dict with the same numeric keys
+        """
+        eeg = np.asarray(eeg, dtype=float)
+        if eeg.ndim == 1:
+            eeg = eeg.reshape(1, -1)
+
+        apf = self._estimate_alpha_peak_freq(eeg, fs)
+        slope = self._estimate_aperiodic_slope(eeg, fs)
+        tar = self._estimate_theta_alpha_ratio(eeg, fs)
+        bai = self._estimate_brain_age_index(eeg, fs)
+
+        reserve_score = self._compute_reserve_score(apf, slope, tar, bai)
+        reserve_category = self._categorize(reserve_score)
+
+        biomarkers = {
+            "reserve_score": round(reserve_score, 2),
+            "brain_age_index": round(bai, 4),
+            "alpha_peak_freq": round(apf, 3),
+            "aperiodic_slope": round(slope, 4),
+            "theta_alpha_ratio": round(tar, 4),
+        }
+
+        return {
+            "reserve_score": round(reserve_score, 2),
+            "brain_age_index": round(bai, 4),
+            "alpha_peak_freq": round(apf, 3),
+            "aperiodic_slope": round(slope, 4),
+            "theta_alpha_ratio": round(tar, 4),
+            "reserve_category": reserve_category,
+            "biomarkers": biomarkers,
+        }
+
+    def update_history(self, score: float) -> None:
+        """Append a reserve score to the longitudinal history."""
+        with self._lock:
+            self._score_history.append(float(score))
+
+    def get_longitudinal_trend(self, n_sessions: Optional[int] = None) -> Dict:
+        """Compute slope and trend from stored score history.
+
+        Args:
+            n_sessions: If given, only use the last n_sessions scores.
+
+        Returns:
+            dict with:
+                slope_per_session  float  points per session
+                trend              str    "improving" | "stable" | "declining"
+                n_sessions         int    number of data points used
+        """
+        with self._lock:
+            history = list(self._score_history)
+
+        if n_sessions is not None:
+            history = history[-n_sessions:]
+
+        if len(history) < 2:
+            return {
+                "slope_per_session": 0.0,
+                "trend": "stable",
+                "n_sessions": len(history),
+            }
+
+        x = np.arange(len(history), dtype=float)
+        slope = float(np.polyfit(x, history, 1)[0])
+
+        if slope > 0.5:
+            trend = "improving"
+        elif slope < -0.5:
+            trend = "declining"
+        else:
+            trend = "stable"
+
+        return {
+            "slope_per_session": round(slope, 4),
+            "trend": trend,
+            "n_sessions": len(history),
+        }
+
+    def reset(self) -> None:
+        """Clear longitudinal history."""
+        with self._lock:
+            self._score_history.clear()
+
+    # ── Private signal-processing helpers ────────────────────────────────────
+
+    def _welch_per_channel(self, eeg: np.ndarray, fs: float):
+        """Run Welch PSD on each channel; return mean freqs and mean PSD."""
+        psds = []
+        freqs_ref = None
+        for ch in range(eeg.shape[0]):
+            sig = eeg[ch]
+            nperseg = min(len(sig), int(fs * 2))
+            if nperseg < 8:
+                continue
+            try:
+                freqs, psd = scipy_signal.welch(sig, fs=fs, nperseg=nperseg)
+                psds.append(psd)
+                if freqs_ref is None:
+                    freqs_ref = freqs
+            except Exception:
+                continue
+
+        if not psds or freqs_ref is None:
+            # Fallback: return flat spectrum with realistic frequencies
+            freqs_ref = np.linspace(0, fs / 2, 128)
+            mean_psd = np.ones_like(freqs_ref) * 1e-6
+        else:
+            mean_psd = np.mean(np.array(psds), axis=0)
+
+        return freqs_ref, mean_psd
+
+    def _band_power(self, freqs: np.ndarray, psd: np.ndarray,
+                    fmin: float, fmax: float) -> float:
+        """Integrate PSD in [fmin, fmax] Hz."""
+        mask = (freqs >= fmin) & (freqs <= fmax)
+        if not np.any(mask):
+            return 1e-10
+        if hasattr(np, "trapezoid"):
+            power = float(np.trapezoid(psd[mask], freqs[mask]))
+        else:
+            power = float(np.trapz(psd[mask], freqs[mask]))
+        return max(power, 1e-10)
+
+    def _estimate_alpha_peak_freq(self, eeg: np.ndarray, fs: float) -> float:
+        """Alpha peak frequency: peak of PSD in 8-13 Hz range.
+
+        Returns a value clamped to [8.0, 13.0].
+        """
+        freqs, psd = self._welch_per_channel(eeg, fs)
+        mask = (freqs >= 8.0) & (freqs <= 13.0)
+        if not np.any(mask):
+            return 10.0
+
+        alpha_freqs = freqs[mask]
+        alpha_psd = psd[mask]
+        peak_idx = int(np.argmax(alpha_psd))
+        apf = float(alpha_freqs[peak_idx])
+        return float(np.clip(apf, 8.0, 13.0))
+
+    def _estimate_aperiodic_slope(self, eeg: np.ndarray, fs: float) -> float:
+        """Fit log-log PSD to estimate 1/f aperiodic slope.
+
+        More negative = steeper 1/f = less reserve (older brain signature).
+        Typical range: -3.5 (steep/aged) to -1.0 (flat/younger).
+        """
+        freqs, psd = self._welch_per_channel(eeg, fs)
+        # Fit in 2-40 Hz range (avoids DC and high-freq noise)
+        valid = (freqs >= 2.0) & (freqs <= 40.0) & (psd > 0)
+        if np.sum(valid) < 4:
+            return -2.0
+
+        log_f = np.log10(freqs[valid] + 1e-12)
+        log_p = np.log10(psd[valid] + 1e-12)
+        try:
+            slope, _ = np.polyfit(log_f, log_p, 1)
+        except Exception:
+            return -2.0
+        return float(slope)
+
+    def _estimate_theta_alpha_ratio(self, eeg: np.ndarray, fs: float) -> float:
+        """Theta (4-8 Hz) / alpha (8-13 Hz) power ratio.
+
+        Higher ratio = more theta relative to alpha = less cognitive reserve.
+        """
+        freqs, psd = self._welch_per_channel(eeg, fs)
+        theta = self._band_power(freqs, psd, 4.0, 8.0)
+        alpha = self._band_power(freqs, psd, 8.0, 13.0)
+        return theta / (alpha + 1e-10)
+
+    def _estimate_brain_age_index(self, eeg: np.ndarray, fs: float) -> float:
+        """Spectral brain age proxy.
+
+        Higher delta/theta relative to alpha → older brain signature → higher index.
+        Returns float in [0, 1].
+        """
+        freqs, psd = self._welch_per_channel(eeg, fs)
+        delta = self._band_power(freqs, psd, 0.5, 4.0)
+        theta = self._band_power(freqs, psd, 4.0, 8.0)
+        alpha = self._band_power(freqs, psd, 8.0, 13.0)
+        beta = self._band_power(freqs, psd, 13.0, 30.0)
+
+        total = delta + theta + alpha + beta + 1e-10
+        # Weighted "old brain" fraction: delta and theta contribute positively;
+        # alpha and beta suppress the index.
+        age_raw = (0.4 * delta + 0.4 * theta - 0.1 * alpha - 0.1 * beta) / total
+        # Shift and scale to [0, 1]
+        bai = float(np.clip((age_raw + 0.4) / 0.8, 0.0, 1.0))
+        return bai
+
+    def _compute_reserve_score(self, apf: float, slope: float,
+                                tar: float, bai: float) -> float:
+        """Combine biomarkers into a single 0-100 reserve score.
+
+        Component weights:
+            APF       30% — higher peak freq = more reserve
+            slope     25% — flatter (less negative) = more reserve
+            TAR       25% — lower theta/alpha ratio = more reserve
+            BAI       20% — lower brain age index = more reserve
+        """
+        # APF score: 8 Hz → 0, 12 Hz → 100
+        apf_score = float(np.clip((apf - 8.0) / 4.0 * 100.0, 0.0, 100.0))
+
+        # Slope score: typical range −3.5 (steep/old) to −1.0 (flat/young)
+        # More negative slope = steeper = less reserve → invert
+        slope_score = float(np.clip((slope - (-3.5)) / ((-1.0) - (-3.5)) * 100.0, 0.0, 100.0))
+
+        # TAR score: 0 → 100 (ratio 0), 100 → 0 (ratio ≥ 5)
+        tar_score = float(np.clip((1.0 - tar / 5.0) * 100.0, 0.0, 100.0))
+
+        # BAI score: 0 → 100 (young brain), 1 → 0 (aged brain)
+        bai_score = float(np.clip((1.0 - bai) * 100.0, 0.0, 100.0))
+
+        reserve = (
+            0.30 * apf_score
+            + 0.25 * slope_score
+            + 0.25 * tar_score
+            + 0.20 * bai_score
+        )
+        return float(np.clip(reserve, 0.0, 100.0))
+
+    def _categorize(self, score: float) -> str:
+        if score >= 65.0:
+            return "high"
+        if score >= 35.0:
+            return "moderate"
+        return "low"
+
+
+# ── Singleton factory ─────────────────────────────────────────────────────────
+
+_instance: Optional[CognitiveReserveEstimator] = None
+_instance_lock = threading.Lock()
+
+
+def get_cognitive_reserve_estimator() -> CognitiveReserveEstimator:
+    """Return the process-wide CognitiveReserveEstimator singleton."""
+    global _instance
+    if _instance is None:
+        with _instance_lock:
+            if _instance is None:
+                _instance = CognitiveReserveEstimator()
+    return _instance

--- a/ml/tests/test_cognitive_reserve_estimator.py
+++ b/ml/tests/test_cognitive_reserve_estimator.py
@@ -1,0 +1,277 @@
+"""Tests for CognitiveReserveEstimator — 25+ tests covering all public API."""
+
+import numpy as np
+import pytest
+
+from models.cognitive_reserve_estimator import (
+    CognitiveReserveEstimator,
+    get_cognitive_reserve_estimator,
+)
+
+FS = 256
+VALID_CATEGORIES = {"low", "moderate", "high"}
+REQUIRED_KEYS = {
+    "reserve_score",
+    "brain_age_index",
+    "alpha_peak_freq",
+    "aperiodic_slope",
+    "theta_alpha_ratio",
+    "reserve_category",
+    "biomarkers",
+}
+BIOMARKER_KEYS = {
+    "reserve_score",
+    "brain_age_index",
+    "alpha_peak_freq",
+    "aperiodic_slope",
+    "theta_alpha_ratio",
+}
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def make_eeg(
+    n_channels: int = 4,
+    duration_s: float = 4.0,
+    fs: int = FS,
+    alpha_amp: float = 10.0,
+    theta_amp: float = 5.0,
+    beta_amp: float = 5.0,
+    delta_amp: float = 2.0,
+    noise_amp: float = 1.0,
+) -> np.ndarray:
+    """Synthetic EEG with controllable band amplitudes."""
+    n = int(fs * duration_s)
+    t = np.arange(n) / fs
+    signals = []
+    for ch in range(n_channels):
+        sig = (
+            alpha_amp * np.sin(2 * np.pi * 10 * t + ch * 0.4)
+            + theta_amp * np.sin(2 * np.pi * 6 * t + ch * 0.2)
+            + beta_amp * np.sin(2 * np.pi * 20 * t + ch * 0.6)
+            + delta_amp * np.sin(2 * np.pi * 2 * t + ch * 0.1)
+            + noise_amp * np.random.default_rng(ch).standard_normal(n)
+        )
+        signals.append(sig)
+    return np.array(signals)
+
+
+@pytest.fixture
+def estimator():
+    """Fresh estimator for each test — avoids singleton state leakage."""
+    return CognitiveReserveEstimator(fs=FS)
+
+
+# ── 1. Init state ──────────────────────────────────────────────────────────────
+
+class TestInit:
+    def test_fresh_history_empty(self, estimator):
+        trend = estimator.get_longitudinal_trend()
+        assert trend["n_sessions"] == 0
+
+    def test_fresh_trend_is_stable(self, estimator):
+        trend = estimator.get_longitudinal_trend()
+        assert trend["trend"] == "stable"
+
+    def test_fresh_slope_is_zero(self, estimator):
+        trend = estimator.get_longitudinal_trend()
+        assert trend["slope_per_session"] == 0.0
+
+
+# ── 2. predict() return structure ─────────────────────────────────────────────
+
+class TestPredictReturnStructure:
+    def test_all_required_keys_present(self, estimator):
+        np.random.seed(0)
+        result = estimator.predict(make_eeg())
+        assert REQUIRED_KEYS.issubset(set(result.keys()))
+
+    def test_biomarkers_subdict_keys(self, estimator):
+        np.random.seed(0)
+        result = estimator.predict(make_eeg())
+        assert BIOMARKER_KEYS.issubset(set(result["biomarkers"].keys()))
+
+    def test_biomarkers_matches_top_level(self, estimator):
+        np.random.seed(1)
+        result = estimator.predict(make_eeg())
+        for key in BIOMARKER_KEYS:
+            assert result["biomarkers"][key] == result[key]
+
+    def test_returns_dict(self, estimator):
+        np.random.seed(2)
+        result = estimator.predict(make_eeg())
+        assert isinstance(result, dict)
+
+
+# ── 3. reserve_score range ─────────────────────────────────────────────────────
+
+class TestReserveScoreRange:
+    def test_in_0_100(self, estimator):
+        np.random.seed(3)
+        r = estimator.predict(make_eeg())
+        assert 0.0 <= r["reserve_score"] <= 100.0
+
+    def test_single_channel_in_range(self, estimator):
+        np.random.seed(4)
+        sig = 10 * np.sin(2 * np.pi * 10 * np.arange(FS * 4) / FS)
+        r = estimator.predict(sig[np.newaxis, :])
+        assert 0.0 <= r["reserve_score"] <= 100.0
+
+    def test_1d_input_in_range(self, estimator):
+        np.random.seed(5)
+        sig = make_eeg(n_channels=1)[0]  # shape (n_samples,)
+        r = estimator.predict(sig)
+        assert 0.0 <= r["reserve_score"] <= 100.0
+
+    def test_high_alpha_higher_reserve(self, estimator):
+        np.random.seed(10)
+        r_high = estimator.predict(make_eeg(alpha_amp=20, theta_amp=2))
+        r_low = estimator.predict(make_eeg(alpha_amp=2, theta_amp=20))
+        # High alpha should produce higher reserve than dominant theta
+        assert r_high["reserve_score"] >= r_low["reserve_score"]
+
+
+# ── 4. brain_age_index range ──────────────────────────────────────────────────
+
+class TestBrainAgeIndex:
+    def test_in_0_1(self, estimator):
+        np.random.seed(6)
+        r = estimator.predict(make_eeg())
+        assert 0.0 <= r["brain_age_index"] <= 1.0
+
+    def test_high_delta_theta_higher_bai(self, estimator):
+        """Brain dominated by delta/theta should have higher age index."""
+        np.random.seed(7)
+        r_old = estimator.predict(make_eeg(delta_amp=20, theta_amp=15, alpha_amp=2))
+        r_young = estimator.predict(make_eeg(delta_amp=1, theta_amp=2, alpha_amp=20))
+        assert r_old["brain_age_index"] >= r_young["brain_age_index"]
+
+
+# ── 5. alpha_peak_freq range ───────────────────────────────────────────────────
+
+class TestAlphaPeakFreq:
+    def test_in_8_13_for_alpha_signal(self, estimator):
+        """Pure 10 Hz signal → APF should be in 8-13 Hz."""
+        np.random.seed(8)
+        t = np.arange(FS * 4) / FS
+        sig = 15 * np.sin(2 * np.pi * 10 * t)
+        r = estimator.predict(sig[np.newaxis, :])
+        assert 8.0 <= r["alpha_peak_freq"] <= 13.0
+
+    def test_multichannel_in_8_13(self, estimator):
+        np.random.seed(9)
+        r = estimator.predict(make_eeg(alpha_amp=15, theta_amp=1, beta_amp=1))
+        assert 8.0 <= r["alpha_peak_freq"] <= 13.0
+
+    def test_always_clamped(self, estimator):
+        """Even for non-alpha-dominant signals the returned value stays in range."""
+        np.random.seed(11)
+        # High theta, almost no alpha
+        r = estimator.predict(make_eeg(alpha_amp=0.5, theta_amp=30))
+        assert 8.0 <= r["alpha_peak_freq"] <= 13.0
+
+
+# ── 6. reserve_category ───────────────────────────────────────────────────────
+
+class TestReserveCategory:
+    def test_valid_string(self, estimator):
+        np.random.seed(12)
+        r = estimator.predict(make_eeg())
+        assert r["reserve_category"] in VALID_CATEGORIES
+
+    def test_high_signal_yields_high_or_moderate(self, estimator):
+        np.random.seed(13)
+        r = estimator.predict(make_eeg(alpha_amp=25, theta_amp=1, beta_amp=5))
+        assert r["reserve_category"] in ("high", "moderate")
+
+    def test_low_alpha_yields_low_or_moderate(self, estimator):
+        np.random.seed(14)
+        r = estimator.predict(make_eeg(alpha_amp=0.5, theta_amp=25, delta_amp=15))
+        assert r["reserve_category"] in ("low", "moderate")
+
+
+# ── 7. update_history and get_longitudinal_trend ──────────────────────────────
+
+class TestUpdateHistoryAndTrend:
+    def test_single_score_n_sessions_1(self, estimator):
+        estimator.update_history(60.0)
+        trend = estimator.get_longitudinal_trend()
+        assert trend["n_sessions"] == 1
+
+    def test_two_scores_trend_computed(self, estimator):
+        estimator.update_history(50.0)
+        estimator.update_history(60.0)
+        trend = estimator.get_longitudinal_trend()
+        assert trend["n_sessions"] == 2
+        assert trend["trend"] in ("improving", "stable", "declining")
+
+    def test_improving_trend(self, estimator):
+        for score in [40.0, 50.0, 60.0, 70.0, 80.0]:
+            estimator.update_history(score)
+        trend = estimator.get_longitudinal_trend()
+        assert trend["trend"] == "improving"
+        assert trend["slope_per_session"] > 0
+
+    def test_declining_trend(self, estimator):
+        for score in [80.0, 70.0, 60.0, 50.0, 40.0]:
+            estimator.update_history(score)
+        trend = estimator.get_longitudinal_trend()
+        assert trend["trend"] == "declining"
+        assert trend["slope_per_session"] < 0
+
+    def test_stable_trend(self, estimator):
+        for score in [60.0, 60.0, 60.0, 60.0]:
+            estimator.update_history(score)
+        trend = estimator.get_longitudinal_trend()
+        assert trend["trend"] == "stable"
+        assert abs(trend["slope_per_session"]) < 0.5
+
+    def test_n_sessions_parameter_limits(self, estimator):
+        for score in range(10):
+            estimator.update_history(float(score * 5))
+        trend = estimator.get_longitudinal_trend(n_sessions=3)
+        assert trend["n_sessions"] == 3
+
+
+# ── 8. reset() ────────────────────────────────────────────────────────────────
+
+class TestReset:
+    def test_reset_clears_history(self, estimator):
+        for _ in range(5):
+            estimator.update_history(55.0)
+        estimator.reset()
+        trend = estimator.get_longitudinal_trend()
+        assert trend["n_sessions"] == 0
+
+    def test_reset_trend_returns_stable(self, estimator):
+        estimator.update_history(70.0)
+        estimator.update_history(80.0)
+        estimator.reset()
+        trend = estimator.get_longitudinal_trend()
+        assert trend["trend"] == "stable"
+
+    def test_predict_still_works_after_reset(self, estimator):
+        np.random.seed(20)
+        estimator.update_history(60.0)
+        estimator.reset()
+        r = estimator.predict(make_eeg())
+        assert 0.0 <= r["reserve_score"] <= 100.0
+
+
+# ── 9. Singleton factory ──────────────────────────────────────────────────────
+
+class TestSingleton:
+    def test_returns_instance(self):
+        inst = get_cognitive_reserve_estimator()
+        assert isinstance(inst, CognitiveReserveEstimator)
+
+    def test_same_object_on_repeated_calls(self):
+        a = get_cognitive_reserve_estimator()
+        b = get_cognitive_reserve_estimator()
+        assert a is b
+
+    def test_singleton_predict_works(self):
+        np.random.seed(99)
+        inst = get_cognitive_reserve_estimator()
+        r = inst.predict(make_eeg())
+        assert REQUIRED_KEYS.issubset(set(r.keys()))


### PR DESCRIPTION
## Summary

- Adds `ml/models/cognitive_reserve_estimator.py` with `CognitiveReserveEstimator` class implementing `predict()` → four spectral biomarkers (alpha peak frequency, aperiodic 1/f slope, theta/alpha ratio, brain age index) combined into a 0-100 reserve score
- Adds `ml/api/routes/cognitive_reserve.py` with four FastAPI endpoints: `POST /cognitive-reserve/analyze`, `POST /cognitive-reserve/update-history`, `GET /cognitive-reserve/trend`, `POST /cognitive-reserve/reset`
- Adds singleton factory `get_cognitive_reserve_estimator()` following existing project patterns
- Registers router in `ml/api/routes/__init__.py`
- 31 tests in `ml/tests/test_cognitive_reserve_estimator.py`, all passing

## Key design decisions

- New file `cognitive_reserve_estimator.py` (not modifying the existing `cognitive_reserve.py` which has a different API surface)
- `predict()` interface matches the spec: returns `reserve_score`, `brain_age_index`, `alpha_peak_freq`, `aperiodic_slope`, `theta_alpha_ratio`, `reserve_category`, `biomarkers` sub-dict
- Longitudinal tracking via `update_history()` / `get_longitudinal_trend()` / `reset()` — thread-safe
- numpy + scipy only (no PyTorch)

## Test plan

- [x] 31 unit tests cover init state, all return keys, value ranges, category validation, trend detection (improving/stable/declining), reset, singleton identity
- [x] `python3 -m pytest tests/test_cognitive_reserve_estimator.py -x -q` → 31 passed