### PR TITLE
feat: add closed-loop emotion regulation biofeedback (#121)

### DIFF
--- a/ml/api/routes/__init__.py
+++ b/ml/api/routes/__init__.py
@@ -75,6 +75,7 @@ from .gru_sleep import router as _gru_sleep
 from .seizure import router as _seizure
 from .emo_adapt import router as _emo_adapt
 from .cognitive_reserve import router as _cognitive_reserve
+from .emotion_regulation import router as _emotion_regulation
 
 router = APIRouter()
 
@@ -120,3 +121,4 @@ router.include_router(_gru_sleep)
 router.include_router(_seizure)
 router.include_router(_emo_adapt)
 router.include_router(_cognitive_reserve)
+router.include_router(_emotion_regulation)

--- a/ml/api/routes/emotion_regulation.py
+++ b/ml/api/routes/emotion_regulation.py
@@ -1,0 +1,113 @@
+"""Closed-loop emotion regulation biofeedback API endpoints.
+
+Endpoints:
+    POST /emotion-regulation/analyze  — analyze one EEG epoch
+    POST /emotion-regulation/update   — update session with new epoch
+    GET  /emotion-regulation/summary  — session summary
+    POST /emotion-regulation/reset    — reset session state
+"""
+
+import logging
+from typing import List, Optional
+
+import numpy as np
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+router = APIRouter(tags=["Emotion Regulation"])
+
+
+# ── Request models ─────────────────────────────────────────────────────────────
+
+class EmotionRegulationAnalyzeRequest(BaseModel):
+    eeg_data: List[List[float]] = Field(
+        ...,
+        description="EEG data: shape [n_channels, n_samples] or [[n_samples]]",
+    )
+    fs: float = Field(default=256.0, gt=0, description="Sampling rate in Hz")
+    duration_sec: int = Field(
+        default=0, ge=0, description="Epoch duration in seconds (informational)"
+    )
+    user_id: str = Field(default="default", description="User identifier")
+
+
+class EmotionRegulationUpdateRequest(BaseModel):
+    eeg_data: List[List[float]] = Field(
+        ...,
+        description="EEG data: shape [n_channels, n_samples] or [[n_samples]]",
+    )
+    fs: float = Field(default=256.0, gt=0, description="Sampling rate in Hz")
+    duration_sec: int = Field(
+        default=1, ge=0, description="Seconds to add to session clock"
+    )
+    user_id: str = Field(default="default", description="User identifier")
+
+
+class EmotionRegulationResetRequest(BaseModel):
+    user_id: str = Field(default="default", description="User identifier")
+
+
+# ── Endpoints ──────────────────────────────────────────────────────────────────
+
+@router.post("/emotion-regulation/analyze")
+async def emotion_regulation_analyze(request: EmotionRegulationAnalyzeRequest):
+    """Analyze one EEG epoch and return emotion regulation biofeedback.
+
+    Returns emotion_state, regulation_score (0–1), biofeedback_cue,
+    alpha_asymmetry, anxiety_index, regulation_trend, session_duration.
+    """
+    try:
+        from models.emotion_regulation import get_emotion_regulation_biofeedback
+        model = get_emotion_regulation_biofeedback(request.user_id)
+        eeg = np.array(request.eeg_data, dtype=np.float32)
+        return model.predict(eeg, fs=request.fs)
+    except Exception as exc:
+        logger.exception("emotion_regulation_analyze failed")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@router.post("/emotion-regulation/update")
+async def emotion_regulation_update(request: EmotionRegulationUpdateRequest):
+    """Update session with a new EEG epoch and advance the session clock.
+
+    Returns the same keys as /analyze plus session_count.
+    """
+    try:
+        from models.emotion_regulation import get_emotion_regulation_biofeedback
+        model = get_emotion_regulation_biofeedback(request.user_id)
+        eeg = np.array(request.eeg_data, dtype=np.float32)
+        return model.update_session(
+            eeg, fs=request.fs, duration_sec=request.duration_sec
+        )
+    except Exception as exc:
+        logger.exception("emotion_regulation_update failed")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@router.get("/emotion-regulation/summary")
+async def emotion_regulation_summary(user_id: str = "default"):
+    """Return session summary statistics.
+
+    Returns mean_regulation_score, peak_score, session_count, dominant_state.
+    """
+    try:
+        from models.emotion_regulation import get_emotion_regulation_biofeedback
+        model = get_emotion_regulation_biofeedback(user_id)
+        return model.get_session_summary()
+    except Exception as exc:
+        logger.exception("emotion_regulation_summary failed")
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@router.post("/emotion-regulation/reset")
+async def emotion_regulation_reset(request: EmotionRegulationResetRequest):
+    """Reset EMA state and session history for the given user."""
+    try:
+        from models.emotion_regulation import get_emotion_regulation_biofeedback
+        model = get_emotion_regulation_biofeedback(request.user_id)
+        model.reset()
+        return {"success": True, "message": "Emotion regulation state reset."}
+    except Exception as exc:
+        logger.exception("emotion_regulation_reset failed")
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/ml/models/emotion_regulation.py
+++ b/ml/models/emotion_regulation.py
@@ -17,11 +17,16 @@ References:
     Harmon-Jones (2003) - Clarifying the emotive functions of asymmetrical
         frontal cortical activity
 """
+import threading
 from typing import Dict, List, Optional
 
 import numpy as np
-_trapezoid = getattr(np, 'trapezoid', None) or getattr(np, 'trapz', None)
-from scipy import signal as scipy_signal
+
+try:
+    from scipy import signal as scipy_signal
+    _SCIPY_AVAILABLE = True
+except ImportError:
+    _SCIPY_AVAILABLE = False
 
 
 # Cognitive reappraisal strategies keyed by current emotional state
@@ -289,7 +294,10 @@ class EmotionRegulationTrainer:
             return 0.0
 
         try:
-            freqs, psd = scipy_signal.welch(signal, fs=fs, nperseg=nperseg)
+            if _SCIPY_AVAILABLE:
+                freqs, psd = scipy_signal.welch(signal, fs=fs, nperseg=nperseg)
+            else:
+                freqs, psd = _numpy_welch(signal, fs=fs, nperseg=nperseg)
         except Exception:
             return 0.0
 
@@ -298,7 +306,7 @@ class EmotionRegulationTrainer:
             return 0.0
 
         if hasattr(np, "trapezoid"):
-            return float(_trapezoid(psd[mask], freqs[mask]))
+            return float(np.trapezoid(psd[mask], freqs[mask]))
         return float(np.trapz(psd[mask], freqs[mask]))
 
     def _frontal_alpha_powers(
@@ -453,3 +461,384 @@ class EmotionRegulationTrainer:
         elif diff < -3.0:
             return "declining"
         return "stable"
+
+
+# ── numpy-only Welch fallback ─────────────────────────────────────────────────
+
+def _numpy_welch(
+    x: np.ndarray, fs: float, nperseg: int
+):
+    """Minimal Welch PSD using numpy FFT (used when scipy is unavailable)."""
+    step = nperseg // 2
+    n = len(x)
+    window = np.hanning(nperseg)
+    segments = []
+    start = 0
+    while start + nperseg <= n:
+        seg = x[start: start + nperseg] * window
+        segments.append(seg)
+        start += step
+    if not segments:
+        freqs = np.fft.rfftfreq(nperseg, d=1.0 / fs)
+        return freqs, np.zeros(len(freqs))
+    psds = [np.abs(np.fft.rfft(s)) ** 2 for s in segments]
+    psd = np.mean(psds, axis=0)
+    win_power = np.sum(window ** 2)
+    psd = psd / (fs * win_power)
+    psd[1:-1] *= 2  # single-sided
+    freqs = np.fft.rfftfreq(nperseg, d=1.0 / fs)
+    return freqs, psd
+
+
+def _band_power(signal: np.ndarray, fs: float, flo: float, fhi: float) -> float:
+    """Compute power in a frequency band via Welch PSD."""
+    nperseg = min(len(signal), int(fs * 2))
+    if nperseg < 8:
+        # Too short: fall back to variance-scaled heuristic
+        return float(np.var(signal)) + 1e-12
+    try:
+        if _SCIPY_AVAILABLE:
+            freqs, psd = scipy_signal.welch(signal, fs=fs, nperseg=nperseg)
+        else:
+            freqs, psd = _numpy_welch(signal, fs=fs, nperseg=nperseg)
+    except Exception:
+        return float(np.var(signal)) + 1e-12
+    mask = (freqs >= flo) & (freqs <= fhi)
+    if not np.any(mask):
+        return 1e-12
+    if hasattr(np, "trapezoid"):
+        return float(np.trapezoid(psd[mask], freqs[mask])) + 1e-12
+    return float(np.trapz(psd[mask], freqs[mask])) + 1e-12
+
+
+# ── EmotionRegulationBiofeedback ──────────────────────────────────────────────
+
+_VALID_EMOTION_STATES = frozenset(
+    ["anxious", "calm", "focused", "stressed", "neutral"]
+)
+_VALID_BIOFEEDBACK_CUES = frozenset(
+    ["increase_alpha", "decrease_beta", "balanced"]
+)
+_VALID_REGULATION_TRENDS = frozenset(["improving", "declining", "stable"])
+
+
+class EmotionRegulationBiofeedback:
+    """Closed-loop neurofeedback for real-time emotion regulation.
+
+    Tracks three EEG biomarkers via exponential moving averages (EMA):
+      - Alpha asymmetry (FAA): log(AF8_alpha) - log(AF7_alpha)
+      - Anxiety index: theta/alpha ratio (frontal theta / frontal alpha)
+      - Arousal regulation: beta/alpha ratio
+
+    All raw data is discarded; only EMA state is retained.
+
+    Args:
+        ema_alpha: EMA decay factor (0–1). Smaller = more smoothing.
+            Default 0.2 gives a 5-frame effective window.
+        trend_window: Number of regulation_score updates used to classify
+            the regulation trend as improving/declining/stable.
+    """
+
+    def __init__(
+        self,
+        ema_alpha: float = 0.2,
+        trend_window: int = 10,
+    ):
+        self._ema_alpha = ema_alpha
+        self._trend_window = trend_window
+
+        # EMA state (per-instance, shared across calls for one user)
+        self._ema_faa: Optional[float] = None
+        self._ema_theta_alpha: Optional[float] = None
+        self._ema_beta_alpha: Optional[float] = None
+
+        # Session accumulators (lightweight — no raw data)
+        self._session_scores: List[float] = []
+        self._session_states: List[str] = []
+        self._session_count: int = 0
+        self._session_duration: int = 0
+
+    # ── Public API ───────────────────────────────────────────────────────────
+
+    def predict(self, eeg: np.ndarray, fs: float = 256.0) -> Dict:
+        """Analyze one EEG epoch and return biofeedback result.
+
+        Args:
+            eeg: (n_channels, n_samples) or (n_samples,) array.
+                For Muse 2: ch0=TP9, ch1=AF7, ch2=AF8, ch3=TP10.
+            fs: Sampling rate in Hz.
+
+        Returns:
+            Dict with keys:
+                emotion_state (str): one of "anxious"|"calm"|"focused"|"stressed"|"neutral"
+                regulation_score (float): 0–1
+                biofeedback_cue (str): "increase_alpha"|"decrease_beta"|"balanced"
+                alpha_asymmetry (float): FAA value
+                anxiety_index (float): 0–1
+                regulation_trend (str): "improving"|"declining"|"stable"
+                session_duration (int): seconds accumulated via update_session()
+        """
+        eeg = np.asarray(eeg, dtype=float)
+        if eeg.ndim == 1:
+            eeg = eeg.reshape(1, -1)
+
+        faa = self._compute_faa(eeg, fs)
+        theta_alpha = self._compute_theta_alpha(eeg, fs)
+        beta_alpha = self._compute_beta_alpha(eeg, fs)
+
+        # Update EMAs
+        self._ema_faa = self._update_ema(self._ema_faa, faa)
+        self._ema_theta_alpha = self._update_ema(self._ema_theta_alpha, theta_alpha)
+        self._ema_beta_alpha = self._update_ema(self._ema_beta_alpha, beta_alpha)
+
+        smooth_faa = self._ema_faa
+        smooth_theta_alpha = self._ema_theta_alpha
+        smooth_beta_alpha = self._ema_beta_alpha
+
+        anxiety_index = self._anxiety_from_theta_alpha(smooth_theta_alpha)
+        regulation_score = self._compute_regulation_score(
+            smooth_faa, anxiety_index, smooth_beta_alpha
+        )
+        emotion_state = self._classify_state(
+            smooth_faa, anxiety_index, smooth_beta_alpha
+        )
+        biofeedback_cue = self._choose_cue(
+            emotion_state, smooth_faa, smooth_beta_alpha
+        )
+        regulation_trend = self._compute_trend()
+
+        return {
+            "emotion_state": emotion_state,
+            "regulation_score": round(float(regulation_score), 4),
+            "biofeedback_cue": biofeedback_cue,
+            "alpha_asymmetry": round(float(smooth_faa), 6),
+            "anxiety_index": round(float(anxiety_index), 4),
+            "regulation_trend": regulation_trend,
+            "session_duration": int(self._session_duration),
+        }
+
+    def update_session(
+        self,
+        eeg: np.ndarray,
+        fs: float = 256.0,
+        duration_sec: int = 0,
+    ) -> Dict:
+        """Accumulate a session epoch and update session counters.
+
+        Args:
+            eeg: EEG epoch for this update.
+            fs: Sampling rate in Hz.
+            duration_sec: Seconds to add to the session clock.
+
+        Returns:
+            Same dict as predict() with session_count included.
+        """
+        result = self.predict(eeg, fs)
+        self._session_count += 1
+        self._session_duration += max(0, int(duration_sec))
+        self._session_scores.append(result["regulation_score"])
+        self._session_states.append(result["emotion_state"])
+        # Keep only last trend_window * 4 entries to bound memory
+        max_keep = max(self._trend_window * 4, 40)
+        if len(self._session_scores) > max_keep:
+            self._session_scores = self._session_scores[-max_keep:]
+            self._session_states = self._session_states[-max_keep:]
+        result["session_count"] = self._session_count
+        return result
+
+    def get_session_summary(self) -> Dict:
+        """Return summary statistics for the current session.
+
+        Returns:
+            Dict with:
+                mean_regulation_score (float): average score 0–1
+                peak_score (float): highest score seen
+                session_count (int): number of update_session() calls
+                dominant_state (str): most frequent emotion_state
+        """
+        if not self._session_scores:
+            return {
+                "mean_regulation_score": 0.0,
+                "peak_score": 0.0,
+                "session_count": 0,
+                "dominant_state": "neutral",
+            }
+
+        dominant = "neutral"
+        if self._session_states:
+            counts: Dict[str, int] = {}
+            for s in self._session_states:
+                counts[s] = counts.get(s, 0) + 1
+            dominant = max(counts, key=lambda k: counts[k])
+
+        return {
+            "mean_regulation_score": round(
+                float(np.mean(self._session_scores)), 4
+            ),
+            "peak_score": round(float(np.max(self._session_scores)), 4),
+            "session_count": self._session_count,
+            "dominant_state": dominant,
+        }
+
+    def reset(self) -> None:
+        """Clear all EMA state and session history."""
+        self._ema_faa = None
+        self._ema_theta_alpha = None
+        self._ema_beta_alpha = None
+        self._session_scores = []
+        self._session_states = []
+        self._session_count = 0
+        self._session_duration = 0
+
+    # ── Private helpers ──────────────────────────────────────────────────────
+
+    def _update_ema(self, current: Optional[float], new: float) -> float:
+        """Update exponential moving average."""
+        if current is None:
+            return new
+        return self._ema_alpha * new + (1.0 - self._ema_alpha) * current
+
+    def _compute_faa(self, eeg: np.ndarray, fs: float) -> float:
+        """Compute frontal alpha asymmetry: log(AF8_alpha) - log(AF7_alpha)."""
+        n_ch = eeg.shape[0]
+        eps = 1e-12
+        if n_ch >= 3:
+            af7_alpha = _band_power(eeg[1], fs, 8.0, 12.0)
+            af8_alpha = _band_power(eeg[2], fs, 8.0, 12.0)
+        elif n_ch == 2:
+            af7_alpha = _band_power(eeg[0], fs, 8.0, 12.0)
+            af8_alpha = _band_power(eeg[1], fs, 8.0, 12.0)
+        else:
+            af7_alpha = _band_power(eeg[0], fs, 8.0, 12.0)
+            af8_alpha = af7_alpha
+        return float(np.log(af8_alpha + eps) - np.log(af7_alpha + eps))
+
+    def _compute_theta_alpha(self, eeg: np.ndarray, fs: float) -> float:
+        """Compute theta/alpha ratio (frontal channel)."""
+        ch = eeg[1] if eeg.shape[0] >= 2 else eeg[0]
+        theta = _band_power(ch, fs, 4.0, 8.0)
+        alpha = _band_power(ch, fs, 8.0, 12.0)
+        return float(theta / (alpha + 1e-12))
+
+    def _compute_beta_alpha(self, eeg: np.ndarray, fs: float) -> float:
+        """Compute beta/alpha ratio (frontal channel)."""
+        ch = eeg[1] if eeg.shape[0] >= 2 else eeg[0]
+        beta = _band_power(ch, fs, 12.0, 30.0)
+        alpha = _band_power(ch, fs, 8.0, 12.0)
+        return float(beta / (alpha + 1e-12))
+
+    def _anxiety_from_theta_alpha(self, theta_alpha: float) -> float:
+        """Map theta/alpha ratio to anxiety_index in [0, 1].
+
+        theta/alpha > 2.5 → highly anxious; < 0.8 → calm.
+        Sigmoid-like mapping clipped to [0, 1].
+        """
+        # Logistic: centre at 1.5, scale 0.8
+        raw = 1.0 / (1.0 + np.exp(-0.8 * (theta_alpha - 1.5)))
+        return float(np.clip(raw, 0.0, 1.0))
+
+    def _compute_regulation_score(
+        self,
+        faa: float,
+        anxiety_index: float,
+        beta_alpha: float,
+    ) -> float:
+        """Compute regulation_score in [0, 1].
+
+        Higher score = better regulated state:
+        - positive FAA (left activation) → higher
+        - lower anxiety_index → higher
+        - moderate beta/alpha (not too high) → higher
+        """
+        # FAA component: sigmoid around 0, positive = good
+        faa_score = float(np.clip(0.5 + faa * 1.5, 0.0, 1.0))
+        # Anxiety component: lower anxiety = higher score
+        anxiety_score = 1.0 - anxiety_index
+        # Arousal component: beta/alpha > 3.0 is stressed; < 1.0 is too drowsy
+        arousal_score = float(np.clip(1.0 - (beta_alpha - 1.5) / 3.0, 0.0, 1.0))
+        # Weighted blend
+        score = 0.4 * faa_score + 0.4 * anxiety_score + 0.2 * arousal_score
+        return float(np.clip(score, 0.0, 1.0))
+
+    def _classify_state(
+        self,
+        faa: float,
+        anxiety_index: float,
+        beta_alpha: float,
+    ) -> str:
+        """Map EEG features to one of the five emotion_state labels."""
+        if anxiety_index > 0.65:
+            # High theta/alpha → anxious or stressed
+            if beta_alpha > 2.5:
+                return "stressed"
+            return "anxious"
+        if faa > 0.15 and anxiety_index < 0.40:
+            # Positive FAA + low anxiety → calm
+            if beta_alpha > 1.8:
+                return "focused"
+            return "calm"
+        if beta_alpha > 2.0 and anxiety_index < 0.50:
+            return "focused"
+        if faa < -0.15 or anxiety_index > 0.55:
+            return "stressed"
+        return "neutral"
+
+    def _choose_cue(
+        self,
+        state: str,
+        faa: float,
+        beta_alpha: float,
+    ) -> str:
+        """Choose the biofeedback cue based on current state."""
+        if state in ("calm", "focused") and faa > 0.0 and beta_alpha < 2.0:
+            return "balanced"
+        if state in ("anxious", "stressed") and faa < 0.0:
+            return "increase_alpha"
+        if beta_alpha > 2.5:
+            return "decrease_beta"
+        if faa < -0.1:
+            return "increase_alpha"
+        return "balanced"
+
+    def _compute_trend(self) -> str:
+        """Classify regulation trend from recent session scores."""
+        scores = self._session_scores
+        n = len(scores)
+        if n < self._trend_window:
+            return "stable"
+        recent = scores[-self._trend_window:]
+        # Linear regression slope via numpy
+        x = np.arange(len(recent), dtype=float)
+        y = np.array(recent, dtype=float)
+        x_mean = np.mean(x)
+        y_mean = np.mean(y)
+        denom = np.sum((x - x_mean) ** 2)
+        if denom < 1e-12:
+            return "stable"
+        slope = float(np.sum((x - x_mean) * (y - y_mean)) / denom)
+        if slope > 0.01:
+            return "improving"
+        if slope < -0.01:
+            return "declining"
+        return "stable"
+
+
+# ── Per-user singleton registry ───────────────────────────────────────────────
+
+_instances: Dict[str, "EmotionRegulationBiofeedback"] = {}
+_instances_lock = threading.Lock()
+
+
+def get_emotion_regulation_biofeedback(
+    user_id: str = "default",
+) -> "EmotionRegulationBiofeedback":
+    """Return a singleton EmotionRegulationBiofeedback for the given user_id.
+
+    Different user_ids return different instances.  Same user_id always
+    returns the same instance (thread-safe).
+    """
+    global _instances
+    with _instances_lock:
+        if user_id not in _instances:
+            _instances[user_id] = EmotionRegulationBiofeedback()
+        return _instances[user_id]

--- a/ml/tests/test_emotion_regulation.py
+++ b/ml/tests/test_emotion_regulation.py
@@ -2,7 +2,11 @@
 import numpy as np
 import pytest
 
-from models.emotion_regulation import EmotionRegulationTrainer
+from models.emotion_regulation import (
+    EmotionRegulationTrainer,
+    EmotionRegulationBiofeedback,
+    get_emotion_regulation_biofeedback,
+)
 
 
 @pytest.fixture
@@ -375,3 +379,375 @@ class TestReset:
         trainer.reset(user_id="a")
         assert trainer.get_session_stats("a")["n_epochs"] == 0
         assert trainer.get_session_stats("b")["n_epochs"] == 1
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# Tests for EmotionRegulationBiofeedback (new closed-loop biofeedback class)
+# ════════════════════════════════════════════════════════════════════════════
+
+FS_BFB = 256
+VALID_EMOTION_STATES = {"anxious", "calm", "focused", "stressed", "neutral"}
+VALID_BIOFEEDBACK_CUES = {"increase_alpha", "decrease_beta", "balanced"}
+VALID_REGULATION_TRENDS = {"improving", "declining", "stable"}
+REQUIRED_PREDICT_KEYS = {
+    "emotion_state",
+    "regulation_score",
+    "biofeedback_cue",
+    "alpha_asymmetry",
+    "anxiety_index",
+    "regulation_trend",
+    "session_duration",
+}
+REQUIRED_SUMMARY_KEYS = {
+    "mean_regulation_score",
+    "peak_score",
+    "session_count",
+    "dominant_state",
+}
+
+
+def _make_bfb_eeg(
+    n_channels: int = 4,
+    duration_s: float = 2.0,
+    dominant_hz: float = 10.0,
+    amplitude: float = 10.0,
+) -> np.ndarray:
+    """Synthetic sinusoidal EEG for biofeedback tests."""
+    n = int(FS_BFB * duration_s)
+    t = np.linspace(0, duration_s, n)
+    sig = amplitude * np.sin(2 * np.pi * dominant_hz * t)
+    if n_channels == 1:
+        return sig.astype(np.float32).reshape(1, -1)
+    return np.tile(sig, (n_channels, 1)).astype(np.float32)
+
+
+def _make_stressed_bfb_eeg() -> np.ndarray:
+    """EEG with high theta and high beta."""
+    n = int(FS_BFB * 2.0)
+    t = np.linspace(0, 2.0, n)
+    theta = 20.0 * np.sin(2 * np.pi * 6 * t)
+    beta = 15.0 * np.sin(2 * np.pi * 22 * t)
+    alpha = 2.0 * np.sin(2 * np.pi * 10 * t)
+    sig = (theta + beta + alpha).astype(np.float32)
+    return np.tile(sig, (4, 1))
+
+
+def _make_calm_bfb_eeg() -> np.ndarray:
+    """EEG with dominant alpha and low beta."""
+    n = int(FS_BFB * 2.0)
+    t = np.linspace(0, 2.0, n)
+    alpha = 20.0 * np.sin(2 * np.pi * 10 * t)
+    theta = 2.0 * np.sin(2 * np.pi * 6 * t)
+    beta = 2.0 * np.sin(2 * np.pi * 18 * t)
+    sig = (alpha + theta + beta).astype(np.float32)
+    return np.tile(sig, (4, 1))
+
+
+@pytest.fixture
+def bfb_model():
+    """Fresh EmotionRegulationBiofeedback for each test."""
+    return EmotionRegulationBiofeedback()
+
+
+# ── Init state ────────────────────────────────────────────────────────────────
+
+class TestBiofeedbackInit:
+    def test_session_count_starts_at_zero(self, bfb_model):
+        summary = bfb_model.get_session_summary()
+        assert summary["session_count"] == 0
+
+    def test_session_summary_returns_zeros_when_empty(self, bfb_model):
+        summary = bfb_model.get_session_summary()
+        assert summary["mean_regulation_score"] == 0.0
+        assert summary["peak_score"] == 0.0
+
+    def test_session_duration_starts_at_zero(self, bfb_model):
+        eeg = _make_bfb_eeg()
+        result = bfb_model.predict(eeg, fs=FS_BFB)
+        assert result["session_duration"] == 0
+
+    def test_regulation_trend_starts_stable(self, bfb_model):
+        eeg = _make_bfb_eeg()
+        result = bfb_model.predict(eeg, fs=FS_BFB)
+        assert result["regulation_trend"] == "stable"
+
+
+# ── predict() output structure ─────────────────────────────────────────────
+
+class TestBiofeedbackPredictOutputKeys:
+    def test_predict_returns_all_required_keys(self, bfb_model):
+        eeg = _make_bfb_eeg()
+        result = bfb_model.predict(eeg, fs=FS_BFB)
+        assert REQUIRED_PREDICT_KEYS.issubset(result.keys()), (
+            f"Missing keys: {REQUIRED_PREDICT_KEYS - result.keys()}"
+        )
+
+    def test_emotion_state_is_valid_string(self, bfb_model):
+        eeg = _make_bfb_eeg()
+        result = bfb_model.predict(eeg, fs=FS_BFB)
+        assert result["emotion_state"] in VALID_EMOTION_STATES
+
+    def test_biofeedback_cue_is_valid(self, bfb_model):
+        eeg = _make_bfb_eeg()
+        result = bfb_model.predict(eeg, fs=FS_BFB)
+        assert result["biofeedback_cue"] in VALID_BIOFEEDBACK_CUES
+
+    def test_regulation_trend_is_valid(self, bfb_model):
+        eeg = _make_bfb_eeg()
+        result = bfb_model.predict(eeg, fs=FS_BFB)
+        assert result["regulation_trend"] in VALID_REGULATION_TRENDS
+
+    def test_regulation_score_is_float(self, bfb_model):
+        eeg = _make_bfb_eeg()
+        result = bfb_model.predict(eeg, fs=FS_BFB)
+        assert isinstance(result["regulation_score"], float)
+
+    def test_anxiety_index_is_float(self, bfb_model):
+        eeg = _make_bfb_eeg()
+        result = bfb_model.predict(eeg, fs=FS_BFB)
+        assert isinstance(result["anxiety_index"], float)
+
+    def test_alpha_asymmetry_is_float(self, bfb_model):
+        eeg = _make_bfb_eeg()
+        result = bfb_model.predict(eeg, fs=FS_BFB)
+        assert isinstance(result["alpha_asymmetry"], float)
+
+    def test_session_duration_is_int(self, bfb_model):
+        eeg = _make_bfb_eeg()
+        result = bfb_model.predict(eeg, fs=FS_BFB)
+        assert isinstance(result["session_duration"], int)
+
+
+# ── predict() value ranges ─────────────────────────────────────────────────
+
+class TestBiofeedbackPredictValueRanges:
+    def test_regulation_score_in_range_0_1(self, bfb_model):
+        eeg = _make_bfb_eeg()
+        result = bfb_model.predict(eeg, fs=FS_BFB)
+        assert 0.0 <= result["regulation_score"] <= 1.0
+
+    def test_anxiety_index_in_range_0_1(self, bfb_model):
+        eeg = _make_bfb_eeg()
+        result = bfb_model.predict(eeg, fs=FS_BFB)
+        assert 0.0 <= result["anxiety_index"] <= 1.0
+
+    def test_regulation_score_non_negative_across_inputs(self, bfb_model):
+        for hz in [4.0, 8.0, 10.0, 20.0, 25.0]:
+            eeg = _make_bfb_eeg(dominant_hz=hz)
+            result = bfb_model.predict(eeg, fs=FS_BFB)
+            assert result["regulation_score"] >= 0.0
+
+    def test_regulation_score_at_most_one_across_inputs(self, bfb_model):
+        for hz in [4.0, 8.0, 10.0, 20.0, 25.0]:
+            eeg = _make_bfb_eeg(dominant_hz=hz)
+            result = bfb_model.predict(eeg, fs=FS_BFB)
+            assert result["regulation_score"] <= 1.0
+
+    def test_anxiety_index_non_negative(self, bfb_model):
+        eeg = _make_bfb_eeg()
+        result = bfb_model.predict(eeg, fs=FS_BFB)
+        assert result["anxiety_index"] >= 0.0
+
+    def test_anxiety_index_at_most_one(self, bfb_model):
+        eeg = _make_bfb_eeg()
+        result = bfb_model.predict(eeg, fs=FS_BFB)
+        assert result["anxiety_index"] <= 1.0
+
+
+# ── Input shape handling ───────────────────────────────────────────────────
+
+class TestBiofeedbackInputShapes:
+    def test_predict_1d_input(self, bfb_model):
+        eeg_1d = _make_bfb_eeg(n_channels=1, duration_s=2.0).reshape(-1)
+        result = bfb_model.predict(eeg_1d, fs=FS_BFB)
+        assert REQUIRED_PREDICT_KEYS.issubset(result.keys())
+
+    def test_predict_2ch_input(self, bfb_model):
+        eeg = _make_bfb_eeg(n_channels=2)
+        result = bfb_model.predict(eeg, fs=FS_BFB)
+        assert REQUIRED_PREDICT_KEYS.issubset(result.keys())
+
+    def test_predict_4ch_input(self, bfb_model):
+        eeg = _make_bfb_eeg(n_channels=4)
+        result = bfb_model.predict(eeg, fs=FS_BFB)
+        assert REQUIRED_PREDICT_KEYS.issubset(result.keys())
+
+
+# ── update_session() ───────────────────────────────────────────────────────
+
+class TestBiofeedbackUpdateSession:
+    def test_update_session_increments_session_count(self, bfb_model):
+        eeg = _make_bfb_eeg()
+        bfb_model.update_session(eeg, fs=FS_BFB, duration_sec=1)
+        bfb_model.update_session(eeg, fs=FS_BFB, duration_sec=1)
+        summary = bfb_model.get_session_summary()
+        assert summary["session_count"] == 2
+
+    def test_update_session_accumulates_duration(self, bfb_model):
+        eeg = _make_bfb_eeg()
+        bfb_model.update_session(eeg, fs=FS_BFB, duration_sec=3)
+        bfb_model.update_session(eeg, fs=FS_BFB, duration_sec=5)
+        result = bfb_model.predict(eeg, fs=FS_BFB)
+        assert result["session_duration"] == 8
+
+    def test_update_session_includes_session_count_key(self, bfb_model):
+        eeg = _make_bfb_eeg()
+        result = bfb_model.update_session(eeg, fs=FS_BFB, duration_sec=1)
+        assert "session_count" in result
+
+    def test_update_session_count_starts_at_1(self, bfb_model):
+        eeg = _make_bfb_eeg()
+        result = bfb_model.update_session(eeg, fs=FS_BFB, duration_sec=1)
+        assert result["session_count"] == 1
+
+    def test_update_session_increments_monotonically(self, bfb_model):
+        eeg = _make_bfb_eeg()
+        for i in range(1, 6):
+            result = bfb_model.update_session(eeg, fs=FS_BFB, duration_sec=1)
+            assert result["session_count"] == i
+
+
+# ── get_session_summary() ──────────────────────────────────────────────────
+
+class TestBiofeedbackGetSessionSummary:
+    def test_summary_has_required_keys(self, bfb_model):
+        eeg = _make_bfb_eeg()
+        bfb_model.update_session(eeg, fs=FS_BFB, duration_sec=1)
+        summary = bfb_model.get_session_summary()
+        assert REQUIRED_SUMMARY_KEYS.issubset(summary.keys()), (
+            f"Missing keys: {REQUIRED_SUMMARY_KEYS - summary.keys()}"
+        )
+
+    def test_summary_session_count_matches_updates(self, bfb_model):
+        eeg = _make_bfb_eeg()
+        for _ in range(7):
+            bfb_model.update_session(eeg, fs=FS_BFB, duration_sec=1)
+        summary = bfb_model.get_session_summary()
+        assert summary["session_count"] == 7
+
+    def test_summary_dominant_state_is_valid(self, bfb_model):
+        eeg = _make_bfb_eeg()
+        for _ in range(3):
+            bfb_model.update_session(eeg, fs=FS_BFB, duration_sec=1)
+        summary = bfb_model.get_session_summary()
+        assert summary["dominant_state"] in VALID_EMOTION_STATES
+
+    def test_summary_mean_score_in_range(self, bfb_model):
+        eeg = _make_bfb_eeg()
+        for _ in range(5):
+            bfb_model.update_session(eeg, fs=FS_BFB, duration_sec=1)
+        summary = bfb_model.get_session_summary()
+        assert 0.0 <= summary["mean_regulation_score"] <= 1.0
+
+    def test_summary_peak_score_gte_mean(self, bfb_model):
+        eeg = _make_bfb_eeg()
+        for _ in range(5):
+            bfb_model.update_session(eeg, fs=FS_BFB, duration_sec=1)
+        summary = bfb_model.get_session_summary()
+        assert summary["peak_score"] >= summary["mean_regulation_score"] - 1e-9
+
+    def test_summary_empty_session_returns_defaults(self, bfb_model):
+        summary = bfb_model.get_session_summary()
+        assert summary["session_count"] == 0
+        assert summary["dominant_state"] == "neutral"
+
+
+# ── reset() ───────────────────────────────────────────────────────────────
+
+class TestBiofeedbackReset:
+    def test_reset_clears_session_count(self, bfb_model):
+        eeg = _make_bfb_eeg()
+        for _ in range(4):
+            bfb_model.update_session(eeg, fs=FS_BFB, duration_sec=1)
+        bfb_model.reset()
+        summary = bfb_model.get_session_summary()
+        assert summary["session_count"] == 0
+
+    def test_reset_clears_session_scores(self, bfb_model):
+        eeg = _make_bfb_eeg()
+        for _ in range(4):
+            bfb_model.update_session(eeg, fs=FS_BFB, duration_sec=1)
+        bfb_model.reset()
+        summary = bfb_model.get_session_summary()
+        assert summary["mean_regulation_score"] == 0.0
+        assert summary["peak_score"] == 0.0
+
+    def test_reset_clears_duration(self, bfb_model):
+        eeg = _make_bfb_eeg()
+        bfb_model.update_session(eeg, fs=FS_BFB, duration_sec=10)
+        bfb_model.reset()
+        result = bfb_model.predict(eeg, fs=FS_BFB)
+        assert result["session_duration"] == 0
+
+    def test_reset_allows_new_session_to_start(self, bfb_model):
+        eeg = _make_bfb_eeg()
+        for _ in range(3):
+            bfb_model.update_session(eeg, fs=FS_BFB, duration_sec=1)
+        bfb_model.reset()
+        bfb_model.update_session(eeg, fs=FS_BFB, duration_sec=1)
+        summary = bfb_model.get_session_summary()
+        assert summary["session_count"] == 1
+
+
+# ── Singleton factory ──────────────────────────────────────────────────────
+
+class TestBiofeedbackSingleton:
+    def test_singleton_same_user_returns_same_instance(self):
+        # Use unique IDs to avoid cross-test interference from other tests
+        a = get_emotion_regulation_biofeedback("bfb_test_user_A_v2")
+        b = get_emotion_regulation_biofeedback("bfb_test_user_A_v2")
+        assert a is b
+
+    def test_singleton_different_users_return_different_instances(self):
+        x = get_emotion_regulation_biofeedback("bfb_user_X_unique_v2")
+        y = get_emotion_regulation_biofeedback("bfb_user_Y_unique_v2")
+        assert x is not y
+
+    def test_singleton_default_user_is_consistent(self):
+        m1 = get_emotion_regulation_biofeedback()
+        m2 = get_emotion_regulation_biofeedback("default")
+        assert m1 is m2
+
+    def test_singleton_is_correct_class(self):
+        m = get_emotion_regulation_biofeedback("bfb_type_check_v2")
+        assert isinstance(m, EmotionRegulationBiofeedback)
+
+
+# ── Trend detection ────────────────────────────────────────────────────────
+
+class TestBiofeedbackRegulationTrend:
+    def test_trend_is_stable_with_insufficient_data(self, bfb_model):
+        eeg = _make_bfb_eeg()
+        result = bfb_model.predict(eeg, fs=FS_BFB)
+        assert result["regulation_trend"] == "stable"
+
+    def test_trend_is_valid_after_many_updates(self, bfb_model):
+        eeg = _make_bfb_eeg()
+        for _ in range(15):
+            bfb_model.update_session(eeg, fs=FS_BFB, duration_sec=1)
+        result = bfb_model.predict(eeg, fs=FS_BFB)
+        assert result["regulation_trend"] in VALID_REGULATION_TRENDS
+
+
+# ── EMA smoothing and different inputs ────────────────────────────────────
+
+class TestBiofeedbackEMASmoothing:
+    def test_predict_stable_score_on_same_input(self, bfb_model):
+        eeg = _make_bfb_eeg()
+        results = [bfb_model.predict(eeg, fs=FS_BFB) for _ in range(5)]
+        scores = [r["regulation_score"] for r in results]
+        # On constant input EMA converges; scores should be close
+        assert max(scores) - min(scores) < 0.5
+
+    def test_predict_calm_vs_stressed_differ_in_at_least_one_metric(self):
+        calm = _make_calm_bfb_eeg()
+        stressed = _make_stressed_bfb_eeg()
+        m_calm = EmotionRegulationBiofeedback()
+        m_stress = EmotionRegulationBiofeedback()
+        r_calm = m_calm.predict(calm, fs=FS_BFB)
+        r_stressed = m_stress.predict(stressed, fs=FS_BFB)
+        assert (
+            r_calm["regulation_score"] != r_stressed["regulation_score"]
+            or r_calm["anxiety_index"] != r_stressed["anxiety_index"]
+            or r_calm["alpha_asymmetry"] != r_stressed["alpha_asymmetry"]
+        )


### PR DESCRIPTION
## Summary

- Implements issue #121: closed-loop emotion regulation neurofeedback via consumer EEG
- Adds `EmotionRegulationBiofeedback` class to `ml/models/emotion_regulation.py` using EMA-based tracking (no raw data retained) of FAA, theta/alpha ratio, and beta/alpha ratio
- Per-user singleton registry via `get_emotion_regulation_biofeedback(user_id)`
- Four FastAPI endpoints in `ml/api/routes/emotion_regulation.py`: `POST /emotion-regulation/analyze`, `POST /emotion-regulation/update`, `GET /emotion-regulation/summary`, `POST /emotion-regulation/reset`
- 25+ tests (78 total in the file) covering init state, output keys, value ranges, input shapes, update_session(), get_session_summary(), reset(), singleton behavior, and EMA smoothing

## What the model tracks

- **Alpha asymmetry (FAA)**: `log(AF8_alpha) - log(AF7_alpha)` — positive = approach/positive affect
- **Anxiety index**: theta/alpha ratio → sigmoid-mapped to [0, 1]
- **Arousal regulation**: beta/alpha ratio
- All state stored as exponential moving averages (α=0.2); no raw signal buffering

## Outputs

`predict()` returns: `emotion_state` ("anxious"|"calm"|"focused"|"stressed"|"neutral"), `regulation_score` (0–1), `biofeedback_cue` ("increase_alpha"|"decrease_beta"|"balanced"), `alpha_asymmetry`, `anxiety_index`, `regulation_trend` ("improving"|"declining"|"stable"), `session_duration`

## Test plan

- [x] `cd ml && python3 -m pytest tests/test_emotion_regulation.py -x -q` → 78 passed
- [x] All required output keys present and value ranges enforced
- [x] Singleton returns same instance per user_id; different user_ids get different instances
- [x] reset() clears all EMA and session state