### PR TITLE
feat: chronic pain biomarker detection API (#129)

### DIFF
--- a/ml/api/routes/__init__.py
+++ b/ml/api/routes/__init__.py
@@ -78,6 +78,7 @@ from .cognitive_reserve import router as _cognitive_reserve
 from .emotion_regulation import router as _emotion_regulation
 from .lucid_induction import router as _lucid_induction
 from .tinnitus import router as _tinnitus
+from .pain import router as _pain
 
 router = APIRouter()
 
@@ -126,3 +127,4 @@ router.include_router(_cognitive_reserve)
 router.include_router(_emotion_regulation)
 router.include_router(_lucid_induction)
 router.include_router(_tinnitus)
+router.include_router(_pain)

--- a/ml/api/routes/pain.py
+++ b/ml/api/routes/pain.py
@@ -1,0 +1,43 @@
+"""Chronic pain biomarker detection from frontal EEG asymmetry.
+
+Endpoint:
+  POST /pain/detect  -- compute pain biomarker score from EEG signals
+
+GitHub issue: #129
+"""
+
+import numpy as np
+from fastapi import APIRouter
+
+from ._shared import EEGInput, _numpy_safe
+from models.pain_detector import PainDetector
+
+router = APIRouter(tags=["pain"])
+
+_detector = PainDetector()
+
+
+@router.post("/pain/detect")
+async def detect_pain_biomarkers(data: EEGInput):
+    """Estimate chronic pain biomarkers from frontal EEG asymmetry.
+
+    Uses resting-state frontal beta/alpha asymmetry as passive pain biomarkers.
+    No pain stimulus required — detects patterns during any EEG session.
+
+    Key biomarkers (Scientific Reports 2024; eBioMedicine 2025):
+    - Beta asymmetry (AF8 - AF7 beta): r = -0.375 with pain severity
+    - Alpha DE asymmetry: strongest differentiator across pain levels
+    - High-beta mean power: elevated during chronic pain states
+
+    Returns pain_biomarker_score (0-1), pain_level classification, and
+    component scores.
+
+    **Disclaimer**: Screening indicator only — not a medical diagnosis.
+    Requires multichannel EEG (AF7 + AF8 at minimum).
+    """
+    signals = np.array(data.signals)
+    if signals.ndim == 1:
+        signals = signals.reshape(1, -1)
+
+    result = _detector.predict(signals, fs=int(data.fs))
+    return _numpy_safe(result)


### PR DESCRIPTION
## Summary

- Adds `ml/api/routes/pain.py` exposing `PainDetector` as `POST /pain/detect`
- Registers the router in `ml/api/routes/__init__.py`
- Closes #129

## Endpoint

`POST /pain/detect` — chronic pain biomarker detection from frontal EEG

**Input**: standard `EEGInput` (signals, fs, user_id)

**Output**:
```json
{
  "pain_biomarker_score": 0.0-1.0,
  "pain_level": "none_detected|mild_indicators|moderate_indicators|elevated_indicators",
  "components": {
    "beta_asymmetry": float,
    "alpha_de_asymmetry": float,
    "high_beta_mean": float
  },
  "disclaimer": "Screening indicator only — not a medical diagnosis"
}
```

## Scientific Basis

- Beta asymmetry (AF8−AF7): r=−0.375 with pain severity — Scientific Reports 2024
- Alpha DE asymmetry: strongest pain severity differentiator — Discover Sensors 2025
- High-beta mean: elevated in chronic pain states — eBioMedicine 2025

## Test plan

- [x] `test_pain_detector.py` — 15/15 tests pass locally
- [ ] CI GitHub Actions pass