### PR TITLE
feat: social cognition detection API (#126)

### DIFF
--- a/ml/api/routes/__init__.py
+++ b/ml/api/routes/__init__.py
@@ -79,6 +79,7 @@ from .emotion_regulation import router as _emotion_regulation
 from .lucid_induction import router as _lucid_induction
 from .tinnitus import router as _tinnitus
 from .pain import router as _pain
+from .social_cognition import router as _social_cognition
 
 router = APIRouter()
 
@@ -128,3 +129,4 @@ router.include_router(_emotion_regulation)
 router.include_router(_lucid_induction)
 router.include_router(_tinnitus)
 router.include_router(_pain)
+router.include_router(_social_cognition)

--- a/ml/api/routes/social_cognition.py
+++ b/ml/api/routes/social_cognition.py
@@ -1,0 +1,82 @@
+"""Social cognition detection API — empathy, mentalizing, and mu suppression.
+
+Endpoints:
+  POST /social-cognition/baseline  -- record non-social resting baseline
+  POST /social-cognition/assess    -- assess social cognitive state from EEG
+  GET  /social-cognition/stats     -- session statistics
+  POST /social-cognition/reset     -- clear baseline and history per user
+
+GitHub issue: #126
+"""
+
+import numpy as np
+from fastapi import APIRouter
+
+from ._shared import EEGInput, _numpy_safe
+from models.social_cognition import SocialCognitionDetector
+
+router = APIRouter(tags=["social-cognition"])
+
+_detector = SocialCognitionDetector()
+
+
+# ── Endpoints ─────────────────────────────────────────────────────────────────
+
+@router.post("/social-cognition/baseline")
+async def set_social_baseline(data: EEGInput):
+    """Record non-social resting baseline for mu and theta powers.
+
+    Call during 2 minutes of eyes-closed rest without social stimuli.
+    Baseline normalizes subsequent assessments for inter-individual
+    differences in resting mu/theta amplitude.
+
+    Returns baseline_mu_power, baseline_theta_power, and baseline_set flag.
+    """
+    signals = np.array(data.signals)
+    if signals.ndim == 1:
+        signals = signals.reshape(1, -1)
+
+    result = _detector.set_baseline(signals, fs=data.fs, user_id=data.user_id)
+    return _numpy_safe(result)
+
+
+@router.post("/social-cognition/assess")
+async def assess_social_cognition(data: EEGInput):
+    """Assess social cognitive state from EEG during social observation.
+
+    Key EEG markers (Perry et al. 2010; Mu et al. 2008):
+    - Mu suppression (8-13 Hz at temporal TP9/TP10): mirror neuron activation
+    - Frontal theta increase: cognitive empathy / mentalizing
+    - Alpha asymmetry: approach motivation during social engagement
+
+    Returns empathy_score (0-1), social_engagement_score (0-1),
+    mu_suppression_ratio, frontal_theta_ratio, social_state label,
+    and behavioural recommendations.
+    """
+    signals = np.array(data.signals)
+    if signals.ndim == 1:
+        signals = signals.reshape(1, -1)
+
+    result = _detector.assess(signals, fs=data.fs, user_id=data.user_id)
+    return _numpy_safe(result)
+
+
+@router.get("/social-cognition/stats")
+async def get_social_cognition_stats(user_id: str = "default"):
+    """Get session statistics for social cognition assessments.
+
+    Returns n_assessments, mean_empathy_score, mean_engagement_score,
+    has_baseline, and state distribution across the session.
+    """
+    result = _detector.get_session_stats(user_id=user_id)
+    return _numpy_safe(result)
+
+
+@router.post("/social-cognition/reset")
+async def reset_social_cognition(user_id: str = "default"):
+    """Clear baseline and session history for a user."""
+    _detector.reset(user_id=user_id)
+    return {
+        "status": "ok",
+        "message": "Social cognition session reset. Record a new baseline before assessing.",
+    }


### PR DESCRIPTION
## Summary
- Exposes `SocialCognitionDetector` (already in `ml/models/social_cognition.py`) as 4 FastAPI endpoints
- `POST /social-cognition/baseline` — record non-social resting baseline (mu + theta powers)
- `POST /social-cognition/assess` — assess empathy, mu suppression, frontal theta, social engagement
- `GET /social-cognition/stats` — session statistics per user
- `POST /social-cognition/reset` — clear baseline and history

## Test plan
- [x] 20/20 tests pass (`ml/tests/test_social_cognition.py`)
- [x] Route registered in `ml/api/routes/__init__.py`
- [x] Follows same singleton + `_numpy_safe` pattern as tinnitus and pain routes

Closes #126