### PR TITLE
feat: brain health score API (#131)

### DIFF
--- a/ml/api/routes/__init__.py
+++ b/ml/api/routes/__init__.py
@@ -81,6 +81,7 @@ from .tinnitus import router as _tinnitus
 from .pain import router as _pain
 from .social_cognition import router as _social_cognition
 from .music_emotion import router as _music_emotion
+from .brain_health import router as _brain_health
 
 router = APIRouter()
 
@@ -132,3 +133,4 @@ router.include_router(_tinnitus)
 router.include_router(_pain)
 router.include_router(_social_cognition)
 router.include_router(_music_emotion)
+router.include_router(_brain_health)

--- a/ml/api/routes/brain_health.py
+++ b/ml/api/routes/brain_health.py
@@ -1,0 +1,83 @@
+"""Brain health score API — composite EEG-based cognitive health indicator.
+
+Endpoints:
+  POST /brain-health/baseline  -- record resting-state baseline
+  POST /brain-health/assess    -- assess current brain health from EEG
+  GET  /brain-health/stats     -- session statistics per user
+  POST /brain-health/reset     -- clear baseline and history per user
+
+GitHub issue: #131
+"""
+
+import numpy as np
+from fastapi import APIRouter
+
+from ._shared import EEGInput, _numpy_safe
+from models.brain_health_score import BrainHealthScore
+
+router = APIRouter(tags=["brain-health"])
+
+_estimator = BrainHealthScore()
+
+
+# ── Endpoints ─────────────────────────────────────────────────────────────────
+
+@router.post("/brain-health/baseline")
+async def set_brain_health_baseline(data: EEGInput):
+    """Record resting-state baseline for brain health estimation.
+
+    Call during 2-3 minutes of eyes-closed rest.
+    Baseline normalises subsequent assessments across five domains:
+    spectral, connectivity, complexity, stability, and asymmetry.
+
+    Returns baseline_set flag and per-domain baseline scores.
+    """
+    signals = np.array(data.signals)
+    if signals.ndim == 1:
+        signals = signals.reshape(1, -1)
+
+    result = _estimator.set_baseline(signals, fs=data.fs, user_id=data.user_id)
+    return _numpy_safe(result)
+
+
+@router.post("/brain-health/assess")
+async def assess_brain_health(data: EEGInput):
+    """Assess brain health from an EEG epoch.
+
+    Composite score (0-100) across five domains:
+    - Spectral: alpha peak frequency, delta/theta ratio
+    - Connectivity: inter-channel coherence
+    - Complexity: Hjorth mobility, spectral entropy
+    - Stability: epoch-to-epoch variance
+    - Asymmetry: frontal alpha asymmetry (FAA)
+
+    Returns overall_score, grade (A/B/C/D/F), domain_scores,
+    recommendations, and has_baseline flag.
+    """
+    signals = np.array(data.signals)
+    if signals.ndim == 1:
+        signals = signals.reshape(1, -1)
+
+    result = _estimator.assess(signals, fs=data.fs, user_id=data.user_id)
+    return _numpy_safe(result)
+
+
+@router.get("/brain-health/stats")
+async def get_brain_health_stats(user_id: str = "default"):
+    """Get session statistics for brain health assessments.
+
+    Returns n_assessments, mean_score, score_trend, mean_domain_scores,
+    best_domain, worst_domain, and has_baseline.
+    """
+    result = _estimator.get_session_stats(user_id=user_id)
+    return _numpy_safe(result)
+
+
+@router.post("/brain-health/reset")
+async def reset_brain_health(user_id: str = "default"):
+    """Clear baseline and session history for a user."""
+    _estimator.reset(user_id=user_id)
+    return {
+        "status": "ok",
+        "message": "Brain health session reset. Record a new baseline before assessing.",
+    }


### PR DESCRIPTION
## Summary
- Exposes \`BrainHealthScore\` (already in \`ml/models/brain_health_score.py\`) as 4 FastAPI endpoints
- \`POST /brain-health/baseline\` — record resting-state baseline (all 5 domains)
- \`POST /brain-health/assess\` — composite 0-100 score + letter grade (A/B/C/D/F) across spectral, connectivity, complexity, stability, and asymmetry domains
- \`GET /brain-health/stats\` — session statistics per user
- \`POST /brain-health/reset\` — clear baseline and session history

## Test plan
- [x] 43/43 tests pass (\`ml/tests/test_brain_health_score.py\`)
- [x] Route registered in \`ml/api/routes/__init__.py\`
- [x] Singleton + \`_numpy_safe\` pattern consistent with other routes

Closes #131