### PR TITLE
feat: add sleep quality prediction API

### DIFF
--- a/ml/api/routes/__init__.py
+++ b/ml/api/routes/__init__.py
@@ -87,6 +87,7 @@ from .neuroadaptive import router as _neuroadaptive
 from .domain_adapt import router as _domain_adapt
 from .few_shot import router as _few_shot
 from .preictal import router as _preictal
+from .sleep_quality import router as _sleep_quality
 
 router = APIRouter()
 
@@ -144,3 +145,4 @@ router.include_router(_neuroadaptive)
 router.include_router(_domain_adapt)
 router.include_router(_few_shot)
 router.include_router(_preictal)
+router.include_router(_sleep_quality)

--- a/ml/api/routes/sleep_quality.py
+++ b/ml/api/routes/sleep_quality.py
@@ -1,0 +1,76 @@
+"""Sleep quality prediction API.
+
+GitHub issue: #122
+"""
+from typing import Optional
+
+import numpy as np
+from fastapi import APIRouter
+from pydantic import BaseModel, Field
+
+from ._shared import _numpy_safe
+from models.sleep_quality_predictor import SleepQualityPredictor
+
+router = APIRouter(tags=["sleep-quality"])
+
+_predictor = SleepQualityPredictor()
+
+
+class SleepInput(BaseModel):
+    n3_pct: float = Field(0.0, ge=0.0, le=1.0, description="Deep sleep (N3) percentage (0-1)")
+    rem_pct: float = Field(0.0, ge=0.0, le=1.0, description="REM sleep percentage (0-1)")
+    n2_pct: float = Field(0.0, ge=0.0, le=1.0, description="N2 sleep percentage (0-1)")
+    n1_pct: float = Field(0.0, ge=0.0, le=1.0, description="N1 sleep percentage (0-1)")
+    wake_pct: float = Field(0.0, ge=0.0, le=1.0, description="Wake percentage (0-1)")
+    sleep_efficiency: float = Field(0.85, ge=0.0, le=1.0, description="Time asleep / time in bed (0-1)")
+    spindle_density: float = Field(0.0, ge=0.0, description="Sleep spindles per minute")
+    total_sleep_hours: float = Field(7.0, ge=0.0, description="Total hours of sleep")
+    waso_minutes: float = Field(0.0, ge=0.0, description="Wake after sleep onset (minutes)")
+    hrv_ms: Optional[float] = Field(None, description="HRV RMSSD during sleep (optional)")
+    user_id: str = Field("default", description="User identifier")
+
+
+@router.post("/sleep-quality/predict")
+async def predict_sleep_quality(data: SleepInput):
+    """Predict sleep quality score and next-day readiness from sleep architecture.
+
+    Returns quality_score (0-100), quality_label, readiness_forecast,
+    component scores (deep, REM, efficiency, duration, continuity, spindles),
+    and improvement suggestions.
+    """
+    result = _predictor.predict(
+        n3_pct=data.n3_pct,
+        rem_pct=data.rem_pct,
+        n2_pct=data.n2_pct,
+        n1_pct=data.n1_pct,
+        wake_pct=data.wake_pct,
+        sleep_efficiency=data.sleep_efficiency,
+        spindle_density=data.spindle_density,
+        total_sleep_hours=data.total_sleep_hours,
+        waso_minutes=data.waso_minutes,
+        hrv_ms=data.hrv_ms,
+        user_id=data.user_id,
+    )
+    return _numpy_safe(result)
+
+
+@router.get("/sleep-quality/trend")
+async def get_sleep_trend(user_id: str = "default", window: int = 7):
+    """Get sleep quality trend over the last N nights."""
+    result = _predictor.get_trend(user_id=user_id, window=window)
+    result["user_id"] = user_id
+    return _numpy_safe(result)
+
+
+@router.get("/sleep-quality/history")
+async def get_sleep_history(user_id: str = "default", last_n: int = 30):
+    """Get sleep quality history for a user."""
+    history = _predictor.get_history(user_id=user_id, last_n=last_n)
+    return _numpy_safe({"history": history, "user_id": user_id, "count": len(history)})
+
+
+@router.post("/sleep-quality/reset")
+async def reset_sleep_quality(user_id: str = "default"):
+    """Clear sleep quality history for a user."""
+    _predictor.reset(user_id=user_id)
+    return {"status": "ok", "message": "Sleep quality history cleared.", "user_id": user_id}


### PR DESCRIPTION
Closes #122

## Summary
- Adds `SleepQualityPredictor` route at `ml/api/routes/sleep_quality.py`
- 4 endpoints: predict, trend, history, reset
- Custom `SleepInput` schema (NOT EEGInput) — takes sleep stage percentages
- Returns quality_score (0-100), quality_label, readiness_forecast, component scores

## Endpoints
- `POST /sleep-quality/predict` — score from n3_pct, rem_pct, sleep_efficiency, etc.
- `GET /sleep-quality/trend` — N-night moving window analysis
- `GET /sleep-quality/history` — per-user sleep quality history
- `POST /sleep-quality/reset` — clear history for a user