### PR TITLE
feat: add motor imagery BCI classification API

### DIFF
--- a/ml/api/routes/__init__.py
+++ b/ml/api/routes/__init__.py
@@ -88,6 +88,7 @@ from .domain_adapt import router as _domain_adapt
 from .few_shot import router as _few_shot
 from .preictal import router as _preictal
 from .sleep_quality import router as _sleep_quality
+from .motor_imagery import router as _motor_imagery
 
 router = APIRouter()
 
@@ -146,3 +147,4 @@ router.include_router(_domain_adapt)
 router.include_router(_few_shot)
 router.include_router(_preictal)
 router.include_router(_sleep_quality)
+router.include_router(_motor_imagery)

--- a/ml/api/routes/motor_imagery.py
+++ b/ml/api/routes/motor_imagery.py
@@ -1,0 +1,91 @@
+"""Motor imagery BCI API.
+
+GitHub issue: #123
+"""
+import numpy as np
+from fastapi import APIRouter
+from pydantic import BaseModel, Field
+
+from ._shared import EEGInput, _numpy_safe
+from models.motor_imagery import MotorImageryClassifier
+
+router = APIRouter(tags=["motor-imagery"])
+
+_classifier = MotorImageryClassifier()
+
+
+class LabelInput(BaseModel):
+    true_label: str = Field(..., description="True imagined movement label (left_hand/right_hand/feet/rest)")
+    user_id: str = Field("default", description="User identifier")
+
+
+@router.post("/motor-imagery/set-baseline")
+async def set_motor_baseline(data: EEGInput):
+    """Record resting-state baseline for ERD computation.
+
+    Call while the user is at rest (no imagined movement).
+    More accurate ERD detection with a good baseline.
+    """
+    signals = np.array(data.signals)
+    if signals.ndim == 1:
+        signals = signals.reshape(1, -1)
+    result = _classifier.set_baseline(eeg_signals=signals, fs=data.fs, user_id=data.user_id)
+    return _numpy_safe(result)
+
+
+@router.post("/motor-imagery/classify")
+async def classify_motor_imagery(data: EEGInput):
+    """Classify imagined movement from EEG mu/beta desynchronization.
+
+    Returns predicted_class (left_hand/right_hand/feet/rest),
+    probabilities, confidence, laterality_index, mu_suppression, and erd_map.
+    """
+    signals = np.array(data.signals)
+    if signals.ndim == 1:
+        signals = signals.reshape(1, -1)
+    result = _classifier.classify(eeg_signals=signals, fs=data.fs, user_id=data.user_id)
+    result["user_id"] = data.user_id
+    return _numpy_safe(result)
+
+
+@router.post("/motor-imagery/label")
+async def submit_motor_label(data: LabelInput):
+    """Submit ground truth label for the last classification (for accuracy tracking)."""
+    valid_labels = {"left_hand", "right_hand", "feet", "rest"}
+    if data.true_label not in valid_labels:
+        from fastapi import HTTPException
+        raise HTTPException(
+            status_code=422,
+            detail=f"true_label must be one of {sorted(valid_labels)}",
+        )
+    _classifier.submit_label(true_label=data.true_label, user_id=data.user_id)
+    return {"status": "ok", "label": data.true_label, "user_id": data.user_id}
+
+
+@router.get("/motor-imagery/accuracy")
+async def get_motor_accuracy(user_id: str = "default"):
+    """Get classification accuracy for a user (requires labeled history)."""
+    accuracy = _classifier.get_accuracy(user_id=user_id)
+    return {"accuracy": accuracy, "user_id": user_id}
+
+
+@router.get("/motor-imagery/stats")
+async def get_motor_stats(user_id: str = "default"):
+    """Get per-class statistics for motor imagery classification."""
+    result = _classifier.get_session_stats(user_id=user_id)
+    result["user_id"] = user_id
+    return _numpy_safe(result)
+
+
+@router.get("/motor-imagery/history")
+async def get_motor_history(user_id: str = "default", last_n: int = 50):
+    """Get classification history for a user."""
+    history = _classifier.get_history(user_id=user_id, last_n=last_n)
+    return _numpy_safe({"history": history, "user_id": user_id, "count": len(history)})
+
+
+@router.post("/motor-imagery/reset")
+async def reset_motor_imagery(user_id: str = "default"):
+    """Clear all motor imagery state for a user."""
+    _classifier.reset(user_id=user_id)
+    return {"status": "ok", "message": "Motor imagery state cleared.", "user_id": user_id}


### PR DESCRIPTION
Closes #123

## Summary
- Adds `MotorImageryClassifier` route at `ml/api/routes/motor_imagery.py`
- 7 endpoints: set-baseline, classify, label, accuracy, stats, history, reset
- Takes raw EEG via `EEGInput`, custom `LabelInput` for ground truth submission
- Classifies imagined movement from mu/beta desynchronization (ERD)
- Valid classes: left_hand, right_hand, feet, rest

## Endpoints
- `POST /motor-imagery/set-baseline` — resting-state ERD reference
- `POST /motor-imagery/classify` — predict imagined movement class
- `POST /motor-imagery/label` — submit ground truth for accuracy tracking
- `GET /motor-imagery/accuracy` — classification accuracy for a user
- `GET /motor-imagery/stats` — per-class statistics
- `GET /motor-imagery/history` — classification history
- `POST /motor-imagery/reset` — clear all state