### PR TITLE
feat: add N400/P600 language ERP monitor (#159)

### DIFF
--- a/ml/api/routes/__init__.py
+++ b/ml/api/routes/__init__.py
@@ -156,3 +156,5 @@ router.include_router(_meditation_depth)
 router.include_router(_neurogame)
 router.include_router(_deception)
 router.include_router(_engagement)
+from .language_erp import router as _language_erp
+router.include_router(_language_erp)

--- a/ml/api/routes/language_erp.py
+++ b/ml/api/routes/language_erp.py
@@ -1,0 +1,76 @@
+"""N400/P600 Language ERP monitoring API (#159)."""
+from __future__ import annotations
+
+import time
+from collections import defaultdict, deque
+from typing import List, Optional
+
+import numpy as np
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+router = APIRouter(prefix="/language-erp", tags=["language-erp"])
+
+
+class LanguageERPInput(BaseModel):
+    signals: List[List[float]]
+    fs: float = 256.0
+    word_onset_ms: float = 0.0
+    user_id: str = "default"
+    context: Optional[str] = None  # "expected" | "unexpected" | None
+
+
+class LanguageERPResult(BaseModel):
+    user_id: str
+    n400_amplitude_uv: float
+    p600_amplitude_uv: float
+    semantic_surprise_index: float
+    syntactic_load_index: float
+    comprehension_score: float
+    is_semantically_surprising: bool
+    is_syntactically_violated: bool
+    model_used: str
+    processed_at: float
+
+
+_history: dict = defaultdict(lambda: deque(maxlen=200))
+
+
+@router.post("/analyze", response_model=LanguageERPResult)
+async def analyze_language_erp(req: LanguageERPInput):
+    """Extract N400 and P600 ERP components from word-locked EEG."""
+    from models.language_erp import get_model
+    signals = np.array(req.signals, dtype=float)
+    if signals.ndim == 1:
+        signals = signals[np.newaxis, :]
+
+    result = get_model().predict(signals, req.fs, req.word_onset_ms)
+
+    out = LanguageERPResult(
+        user_id=req.user_id,
+        n400_amplitude_uv=result["n400_amplitude_uv"],
+        p600_amplitude_uv=result["p600_amplitude_uv"],
+        semantic_surprise_index=result["semantic_surprise_index"],
+        syntactic_load_index=result["syntactic_load_index"],
+        comprehension_score=result["comprehension_score"],
+        is_semantically_surprising=result["semantic_surprise_index"] > 0.6,
+        is_syntactically_violated=result["syntactic_load_index"] > 0.6,
+        model_used=result["model_used"],
+        processed_at=time.time(),
+    )
+    _history[req.user_id].append(out.model_dump())
+    return out
+
+
+@router.get("/history/{user_id}")
+async def get_history(user_id: str, limit: int = 50):
+    """Return recent language ERP analysis history for a user."""
+    items = list(_history[user_id])[-limit:]
+    return {"user_id": user_id, "count": len(items), "history": items}
+
+
+@router.post("/reset/{user_id}")
+async def reset_history(user_id: str):
+    """Clear language ERP history for a user."""
+    _history[user_id].clear()
+    return {"user_id": user_id, "status": "reset"}

--- a/ml/models/language_erp.py
+++ b/ml/models/language_erp.py
@@ -1,0 +1,104 @@
+"""N400/P600 ERP-based language processing monitor.
+
+N400: negative deflection 300-500ms post word onset — semantic surprise.
+P600: positive deflection 500-800ms post word onset — syntactic violation.
+
+References:
+    Kutas & Federmeier (2011) — 30 years of N400
+    Osterhout & Holcomb (1992) — P600 syntactic ERP
+    Hollenstein et al. (2019) — EEG + NLP reading datasets
+"""
+from __future__ import annotations
+
+import numpy as np
+from typing import Dict
+
+
+class LanguageERPModel:
+    """Feature-based N400/P600 extractor for Muse 2 (4-channel, 256 Hz)."""
+
+    def predict(self, signals: np.ndarray, fs: float = 256.0,
+                word_onset_ms: float = 0.0) -> Dict:
+        """Compute N400 and P600 language ERP features.
+
+        Args:
+            signals: (n_channels, n_samples) or (n_samples,) EEG array
+            fs: sampling rate (Hz)
+            word_onset_ms: sample offset of word onset within signals (ms)
+
+        Returns:
+            dict with n400_amplitude, p600_amplitude, semantic_surprise_index,
+            syntactic_load_index, comprehension_score, model_used
+        """
+        if signals.ndim == 1:
+            signals = signals[np.newaxis, :]
+
+        n_ch, n_samples = signals.shape
+
+        onset_samp = int(word_onset_ms * fs / 1000)
+
+        def window_mean(sig, t_start_ms, t_end_ms):
+            s = onset_samp + int(t_start_ms * fs / 1000)
+            e = onset_samp + int(t_end_ms * fs / 1000)
+            s = max(0, min(s, n_samples - 1))
+            e = max(s + 1, min(e, n_samples))
+            return float(np.mean(sig[s:e])) if e > s else 0.0
+
+        # Use mean across available channels (AF7/AF8 frontal N400 proxy)
+        ch_mean = np.mean(signals, axis=0)
+
+        # Baseline: pre-stimulus -200 to 0 ms (or first 50 samples if no pre)
+        baseline_s = max(0, onset_samp - int(0.2 * fs))
+        baseline_e = onset_samp if onset_samp > 0 else min(int(0.05 * fs), n_samples)
+        baseline = float(np.mean(ch_mean[baseline_s:baseline_e])) if baseline_e > baseline_s else 0.0
+
+        # N400 window: 300–500 ms post onset
+        n400_raw = window_mean(ch_mean, 300, 500) - baseline
+
+        # P600 window: 500–800 ms post onset
+        p600_raw = window_mean(ch_mean, 500, 800) - baseline
+
+        # Semantic surprise index: larger negative N400 → more surprise
+        # Normalize to 0–1 (typical N400 effect: 2–8 µV)
+        semantic_surprise = float(np.clip(-n400_raw / 8.0 + 0.5, 0.0, 1.0))
+
+        # Syntactic load index: larger positive P600 → more syntactic effort
+        syntactic_load = float(np.clip(p600_raw / 8.0 + 0.5, 0.0, 1.0))
+
+        # Band-power features for supplementary indices
+        from scipy.signal import welch
+        nperseg = min(n_samples, int(fs * 2))
+        f, psd = welch(ch_mean, fs=fs, nperseg=nperseg)
+
+        def bp(flo, fhi):
+            idx = (f >= flo) & (f <= fhi)
+            return float(np.mean(psd[idx])) if idx.any() else 1e-9
+
+        theta = bp(4, 8)
+        alpha = bp(8, 12)
+        beta = bp(12, 30)
+
+        # Comprehension score: high alpha (relaxed reading) + low theta (low confusion)
+        comprehension_score = float(np.clip(
+            0.5 * (alpha / (alpha + theta + 1e-9)) +
+            0.5 * (1.0 - beta / (alpha + beta + 1e-9)),
+            0.0, 1.0
+        ))
+
+        return {
+            "n400_amplitude_uv": round(n400_raw, 4),
+            "p600_amplitude_uv": round(p600_raw, 4),
+            "semantic_surprise_index": round(semantic_surprise, 4),
+            "syntactic_load_index": round(syntactic_load, 4),
+            "comprehension_score": round(comprehension_score, 4),
+            "theta_power": round(theta, 6),
+            "alpha_power": round(alpha, 6),
+            "model_used": "feature_based_erp",
+        }
+
+
+_model = LanguageERPModel()
+
+
+def get_model() -> LanguageERPModel:
+    return _model

--- a/ml/tests/test_language_erp.py
+++ b/ml/tests/test_language_erp.py
@@ -1,0 +1,174 @@
+"""Tests for N400/P600 language ERP model and API routes."""
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+RNG = np.random.default_rng(42)
+
+
+def make_signals(n_ch=4, n_samp=512, fs=256.0):
+    return (RNG.standard_normal((n_ch, n_samp)) * 5.0).tolist()
+
+
+# ── Model unit tests ─────────────────────────────────────────────────────────
+
+def test_model_returns_required_keys():
+    from models.language_erp import get_model
+    sig = np.zeros((4, 512))
+    result = get_model().predict(sig, 256.0)
+    for key in ("n400_amplitude_uv", "p600_amplitude_uv",
+                "semantic_surprise_index", "syntactic_load_index",
+                "comprehension_score", "model_used"):
+        assert key in result
+
+
+def test_model_1d_input():
+    from models.language_erp import get_model
+    sig = np.random.randn(512) * 3.0
+    result = get_model().predict(sig, 256.0)
+    assert "n400_amplitude_uv" in result
+
+
+def test_model_4ch_input():
+    from models.language_erp import get_model
+    sig = np.random.randn(4, 512) * 3.0
+    result = get_model().predict(sig, 256.0)
+    assert isinstance(result["n400_amplitude_uv"], float)
+
+
+def test_semantic_surprise_in_range():
+    from models.language_erp import get_model
+    sig = np.random.randn(4, 512) * 3.0
+    result = get_model().predict(sig, 256.0)
+    assert 0.0 <= result["semantic_surprise_index"] <= 1.0
+
+
+def test_syntactic_load_in_range():
+    from models.language_erp import get_model
+    sig = np.random.randn(4, 512) * 3.0
+    result = get_model().predict(sig, 256.0)
+    assert 0.0 <= result["syntactic_load_index"] <= 1.0
+
+
+def test_comprehension_score_in_range():
+    from models.language_erp import get_model
+    sig = np.random.randn(4, 512) * 3.0
+    result = get_model().predict(sig, 256.0)
+    assert 0.0 <= result["comprehension_score"] <= 1.0
+
+
+def test_model_used_field():
+    from models.language_erp import get_model
+    sig = np.zeros((2, 256))
+    result = get_model().predict(sig, 256.0)
+    assert result["model_used"] == "feature_based_erp"
+
+
+def test_zero_signal_stable():
+    from models.language_erp import get_model
+    sig = np.zeros((4, 512))
+    result = get_model().predict(sig, 256.0)
+    assert result["n400_amplitude_uv"] == 0.0
+
+
+def test_word_onset_offset():
+    from models.language_erp import get_model
+    sig = np.random.randn(4, 1024) * 5.0
+    r1 = get_model().predict(sig, 256.0, word_onset_ms=0.0)
+    r2 = get_model().predict(sig, 256.0, word_onset_ms=200.0)
+    # Different onsets should (usually) give different amplitudes
+    assert isinstance(r1["n400_amplitude_uv"], float)
+    assert isinstance(r2["n400_amplitude_uv"], float)
+
+
+def test_singleton_same_object():
+    from models.language_erp import get_model
+    assert get_model() is get_model()
+
+
+# ── API route tests ───────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="module")
+def client():
+    import sys, os
+    sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+    from fastapi import FastAPI
+    from api.routes.language_erp import router
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+def test_analyze_200(client):
+    r = client.post("/language-erp/analyze", json={
+        "signals": make_signals(), "fs": 256.0, "user_id": "u1"
+    })
+    assert r.status_code == 200
+
+
+def test_analyze_response_fields(client):
+    r = client.post("/language-erp/analyze", json={
+        "signals": make_signals(), "fs": 256.0, "user_id": "u1"
+    })
+    d = r.json()
+    for key in ("n400_amplitude_uv", "p600_amplitude_uv",
+                "semantic_surprise_index", "comprehension_score",
+                "is_semantically_surprising", "is_syntactically_violated"):
+        assert key in d
+
+
+def test_analyze_is_deceptive_bool(client):
+    r = client.post("/language-erp/analyze", json={
+        "signals": make_signals(), "fs": 256.0, "user_id": "u2"
+    })
+    assert isinstance(r.json()["is_semantically_surprising"], bool)
+
+
+def test_analyze_with_word_onset(client):
+    r = client.post("/language-erp/analyze", json={
+        "signals": make_signals(n_samp=1024), "fs": 256.0,
+        "word_onset_ms": 200.0, "user_id": "u3"
+    })
+    assert r.status_code == 200
+
+
+def test_history_starts_populated(client):
+    r = client.get("/language-erp/history/u1")
+    assert r.status_code == 200
+    assert r.json()["count"] >= 1
+
+
+def test_history_empty_user(client):
+    r = client.get("/language-erp/history/nonexistent_xyz")
+    assert r.json()["count"] == 0
+
+
+def test_reset_clears_history(client):
+    client.post("/language-erp/analyze", json={
+        "signals": make_signals(), "fs": 256.0, "user_id": "resetme"
+    })
+    client.post("/language-erp/reset/resetme")
+    r = client.get("/language-erp/history/resetme")
+    assert r.json()["count"] == 0
+
+
+def test_reset_returns_status(client):
+    r = client.post("/language-erp/reset/someuser")
+    assert r.json()["status"] == "reset"
+
+
+def test_history_limit(client):
+    for _ in range(5):
+        client.post("/language-erp/analyze", json={
+            "signals": make_signals(), "fs": 256.0, "user_id": "limituser"
+        })
+    r = client.get("/language-erp/history/limituser?limit=3")
+    assert r.json()["count"] <= 3
+
+
+def test_single_channel_input(client):
+    r = client.post("/language-erp/analyze", json={
+        "signals": [list(np.random.randn(512) * 3.0)],
+        "fs": 256.0, "user_id": "sc"
+    })
+    assert r.status_code == 200


### PR DESCRIPTION
Implements N400/P600 ERP-based language processing monitoring.

- **N400** (300-500ms): semantic surprise index — larger for unexpected words
- **P600** (500-800ms): syntactic load index — larger for grammatical violations
- Comprehension score from alpha/theta power ratio
- 3 endpoints: POST /language-erp/analyze, GET /history/{user_id}, POST /reset/{user_id}
- 20 passing tests

Closes #159