### PR TITLE
feat: add EEG visual attention and gaze zone estimator (#160)

### DIFF
--- a/ml/api/routes/__init__.py
+++ b/ml/api/routes/__init__.py
@@ -156,3 +156,5 @@ router.include_router(_meditation_depth)
 router.include_router(_neurogame)
 router.include_router(_deception)
 router.include_router(_engagement)
+from .visual_attention import router as _visual_attention
+router.include_router(_visual_attention)

--- a/ml/api/routes/visual_attention.py
+++ b/ml/api/routes/visual_attention.py
@@ -1,0 +1,75 @@
+"""EEG visual attention and gaze zone estimation API (#160)."""
+from __future__ import annotations
+
+import time
+from collections import defaultdict, deque
+from typing import List
+
+import numpy as np
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+router = APIRouter(prefix="/visual-attention", tags=["visual-attention"])
+
+
+class VisualAttentionInput(BaseModel):
+    signals: List[List[float]]
+    fs: float = 256.0
+    user_id: str = "default"
+
+
+class VisualAttentionResult(BaseModel):
+    user_id: str
+    attention_zone: str
+    horizontal_bias: float
+    vertical_bias: float
+    alpha_suppression: float
+    visual_engagement: float
+    sustained_attention_index: float
+    grid_col: int
+    grid_row: int
+    model_used: str
+    processed_at: float
+
+
+_history: dict = defaultdict(lambda: deque(maxlen=200))
+
+
+@router.post("/analyze", response_model=VisualAttentionResult)
+async def analyze_visual_attention(req: VisualAttentionInput):
+    """Estimate visual attention zone from EEG alpha lateralization."""
+    from models.visual_attention import get_model
+    signals = np.array(req.signals, dtype=float)
+    if signals.ndim == 1:
+        signals = signals[np.newaxis, :]
+
+    r = get_model().predict(signals, req.fs)
+    out = VisualAttentionResult(
+        user_id=req.user_id,
+        attention_zone=r["attention_zone"],
+        horizontal_bias=r["horizontal_bias"],
+        vertical_bias=r["vertical_bias"],
+        alpha_suppression=r["alpha_suppression"],
+        visual_engagement=r["visual_engagement"],
+        sustained_attention_index=r["sustained_attention_index"],
+        grid_col=r["grid_col"],
+        grid_row=r["grid_row"],
+        model_used=r["model_used"],
+        processed_at=time.time(),
+    )
+    _history[req.user_id].append(out.model_dump())
+    return out
+
+
+@router.get("/history/{user_id}")
+async def get_history(user_id: str, limit: int = 50):
+    """Return recent visual attention history for a user."""
+    items = list(_history[user_id])[-limit:]
+    return {"user_id": user_id, "count": len(items), "history": items}
+
+
+@router.post("/reset/{user_id}")
+async def reset_history(user_id: str):
+    """Clear visual attention history for a user."""
+    _history[user_id].clear()
+    return {"user_id": user_id, "status": "reset"}

--- a/ml/models/visual_attention.py
+++ b/ml/models/visual_attention.py
@@ -1,0 +1,135 @@
+"""EEG-based visual attention and gaze zone estimation.
+
+Alpha suppression (8-12 Hz) at occipital-like channels indexes visual
+cortex engagement. Posterior alpha ERD (event-related desynchronization)
+marks where attention is directed. With Muse 2's frontal channels we use
+alpha asymmetry and theta bursts as proxies.
+
+References:
+    Thut et al. (2006) — alpha-band oscillations as attention gate
+    Kelly et al. (2006) — alpha lateralization and spatial attention
+    Worden et al. (2000) — posterior alpha and saccadic preparation
+"""
+from __future__ import annotations
+
+import numpy as np
+from typing import Dict
+
+
+class VisualAttentionModel:
+    """Estimates visual attention zone from EEG band power."""
+
+    # Gaze zones for 3x3 grid
+    ZONES = [
+        "top-left", "top-center", "top-right",
+        "mid-left", "center",     "mid-right",
+        "bot-left", "bot-center", "bot-right",
+    ]
+
+    def predict(self, signals: np.ndarray, fs: float = 256.0) -> Dict:
+        """Estimate visual attention direction and engagement.
+
+        Args:
+            signals: (n_channels, n_samples) or (n_samples,) EEG
+            fs: sampling rate Hz
+
+        Returns:
+            dict with attention_zone, horizontal_bias, vertical_bias,
+            alpha_suppression, visual_engagement, sustained_attention_index
+        """
+        if signals.ndim == 1:
+            signals = signals[np.newaxis, :]
+
+        n_ch, n_samples = signals.shape
+
+        from scipy.signal import welch
+        nperseg = min(n_samples, int(fs * 2))
+
+        def bp(sig, flo, fhi):
+            f, p = welch(sig, fs=fs, nperseg=nperseg)
+            idx = (f >= flo) & (f <= fhi)
+            return float(np.mean(p[idx])) if idx.any() else 1e-9
+
+        # Per-channel band powers (use up to 4 channels)
+        ch_alpha, ch_theta, ch_beta = [], [], []
+        for i in range(min(n_ch, 4)):
+            ch_alpha.append(bp(signals[i], 8, 12))
+            ch_theta.append(bp(signals[i], 4, 8))
+            ch_beta.append(bp(signals[i], 12, 30))
+
+        alpha = np.array(ch_alpha)
+        theta = np.array(ch_theta)
+        beta  = np.array(ch_beta)
+
+        # Horizontal bias: AF7 (left) vs AF8 (right) alpha asymmetry
+        # More left alpha suppression → attention directed right, and vice versa
+        if n_ch >= 3:
+            # ch1=AF7 (left), ch2=AF8 (right)
+            left_alpha  = ch_alpha[1] if n_ch > 1 else ch_alpha[0]
+            right_alpha = ch_alpha[2] if n_ch > 2 else ch_alpha[0]
+            # Positive → rightward attention; negative → leftward
+            h_bias = float(np.clip(
+                np.log(left_alpha + 1e-9) - np.log(right_alpha + 1e-9), -2, 2
+            ) / 2.0)  # [-1, 1]
+        else:
+            h_bias = 0.0
+
+        # Vertical bias: high alpha → downward (resting gaze); low alpha + high theta → upward
+        mean_alpha = float(np.mean(alpha))
+        mean_theta = float(np.mean(theta))
+        mean_beta  = float(np.mean(beta))
+        # Upward gaze associated with increased frontal theta (working memory/visual search)
+        v_bias = float(np.clip(
+            (mean_theta / (mean_alpha + 1e-9) - 0.8) / 1.5, -1.0, 1.0
+        ))
+
+        # Map biases to 3x3 zone grid
+        # h: -1=left, 0=center, +1=right  →  col 0,1,2
+        col = int(np.clip(round((h_bias + 1.0) * 1.0), 0, 2))
+        # v: -1=bottom, 0=mid, +1=top  →  row 0 (top), 1 (mid), 2 (bot)
+        row = int(np.clip(round((1.0 - v_bias) * 1.0), 0, 2))
+        zone = self.ZONES[row * 3 + col]
+
+        # Alpha suppression index (0=no suppression, 1=full suppression)
+        # Lower alpha relative to baseline (mean) = more visual engagement
+        alpha_suppression = float(np.clip(
+            1.0 - mean_alpha / (mean_alpha + mean_beta + 1e-9), 0.0, 1.0
+        ))
+
+        # Visual engagement = beta/(alpha+beta)
+        visual_engagement = float(np.clip(
+            mean_beta / (mean_alpha + mean_beta + 1e-9), 0.0, 1.0
+        ))
+
+        # Sustained attention: low variability in alpha + high beta
+        if n_samples >= int(fs):
+            # Split into 4 quarters and measure alpha variance
+            q = n_samples // 4
+            quarter_alphas = [
+                bp(signals[0], 8, 12) if signals.shape[1] >= (i+1)*q
+                else mean_alpha
+                for i in range(4)
+            ]
+            alpha_var = float(np.var(quarter_alphas))
+            sustained = float(np.clip(1.0 - alpha_var * 10, 0.0, 1.0))
+        else:
+            sustained = 0.5
+
+        return {
+            "attention_zone": zone,
+            "horizontal_bias": round(h_bias, 4),
+            "vertical_bias": round(v_bias, 4),
+            "alpha_suppression": round(alpha_suppression, 4),
+            "visual_engagement": round(visual_engagement, 4),
+            "sustained_attention_index": round(sustained, 4),
+            "grid_col": col,
+            "grid_row": row,
+            "model_used": "feature_based_alpha_lateralization",
+        }
+
+
+_model = VisualAttentionModel()
+
+
+def get_model() -> VisualAttentionModel:
+    return _model

--- a/ml/tests/test_visual_attention.py
+++ b/ml/tests/test_visual_attention.py
@@ -1,0 +1,148 @@
+"""Tests for EEG visual attention and gaze zone estimation."""
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+RNG = np.random.default_rng(7)
+ZONES = [
+    "top-left","top-center","top-right",
+    "mid-left","center","mid-right",
+    "bot-left","bot-center","bot-right",
+]
+
+
+def make_sigs(n_ch=4, n=512):
+    return (RNG.standard_normal((n_ch, n)) * 5.0).tolist()
+
+
+# ── Model tests ───────────────────────────────────────────────────────────────
+
+def test_model_keys():
+    from models.visual_attention import get_model
+    r = get_model().predict(np.zeros((4, 512)), 256.0)
+    for k in ("attention_zone","horizontal_bias","vertical_bias",
+              "alpha_suppression","visual_engagement","sustained_attention_index"):
+        assert k in r
+
+
+def test_attention_zone_valid():
+    from models.visual_attention import get_model
+    r = get_model().predict(np.random.randn(4, 512) * 3, 256.0)
+    assert r["attention_zone"] in ZONES
+
+
+def test_horizontal_bias_range():
+    from models.visual_attention import get_model
+    r = get_model().predict(np.random.randn(4, 512) * 3, 256.0)
+    assert -1.0 <= r["horizontal_bias"] <= 1.0
+
+
+def test_vertical_bias_range():
+    from models.visual_attention import get_model
+    r = get_model().predict(np.random.randn(4, 512) * 3, 256.0)
+    assert -1.0 <= r["vertical_bias"] <= 1.0
+
+
+def test_alpha_suppression_range():
+    from models.visual_attention import get_model
+    r = get_model().predict(np.random.randn(4, 512) * 3, 256.0)
+    assert 0.0 <= r["alpha_suppression"] <= 1.0
+
+
+def test_visual_engagement_range():
+    from models.visual_attention import get_model
+    r = get_model().predict(np.random.randn(4, 512) * 3, 256.0)
+    assert 0.0 <= r["visual_engagement"] <= 1.0
+
+
+def test_sustained_attention_range():
+    from models.visual_attention import get_model
+    r = get_model().predict(np.random.randn(4, 512) * 3, 256.0)
+    assert 0.0 <= r["sustained_attention_index"] <= 1.0
+
+
+def test_grid_col_range():
+    from models.visual_attention import get_model
+    r = get_model().predict(np.random.randn(4, 512) * 3, 256.0)
+    assert r["grid_col"] in (0, 1, 2)
+
+
+def test_grid_row_range():
+    from models.visual_attention import get_model
+    r = get_model().predict(np.random.randn(4, 512) * 3, 256.0)
+    assert r["grid_row"] in (0, 1, 2)
+
+
+def test_1d_input():
+    from models.visual_attention import get_model
+    r = get_model().predict(np.random.randn(256) * 3, 256.0)
+    assert r["attention_zone"] in ZONES
+
+
+def test_zero_signal_stable():
+    from models.visual_attention import get_model
+    r = get_model().predict(np.zeros((4, 512)), 256.0)
+    assert r["attention_zone"] in ZONES
+
+
+def test_singleton():
+    from models.visual_attention import get_model
+    assert get_model() is get_model()
+
+
+# ── API tests ─────────────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="module")
+def client():
+    import sys, os
+    sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+    from fastapi import FastAPI
+    from api.routes.visual_attention import router
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+def test_analyze_200(client):
+    r = client.post("/visual-attention/analyze", json={"signals": make_sigs(), "user_id": "u1"})
+    assert r.status_code == 200
+
+
+def test_analyze_fields(client):
+    r = client.post("/visual-attention/analyze", json={"signals": make_sigs(), "user_id": "u1"})
+    d = r.json()
+    for k in ("attention_zone","horizontal_bias","alpha_suppression","visual_engagement"):
+        assert k in d
+
+
+def test_zone_in_valid_set(client):
+    r = client.post("/visual-attention/analyze", json={"signals": make_sigs(), "user_id": "u1"})
+    assert r.json()["attention_zone"] in ZONES
+
+
+def test_history_populated(client):
+    r = client.get("/visual-attention/history/u1")
+    assert r.json()["count"] >= 1
+
+
+def test_history_empty_user(client):
+    r = client.get("/visual-attention/history/nobody_xyz")
+    assert r.json()["count"] == 0
+
+
+def test_reset(client):
+    client.post("/visual-attention/analyze", json={"signals": make_sigs(), "user_id": "reset_u"})
+    client.post("/visual-attention/reset/reset_u")
+    assert client.get("/visual-attention/history/reset_u").json()["count"] == 0
+
+
+def test_reset_status(client):
+    r = client.post("/visual-attention/reset/x")
+    assert r.json()["status"] == "reset"
+
+
+def test_single_channel(client):
+    r = client.post("/visual-attention/analyze", json={
+        "signals": [list(np.random.randn(512) * 3)], "user_id": "sc"
+    })
+    assert r.status_code == 200


### PR DESCRIPTION
Implements EEG-based visual attention monitoring using alpha lateralization.

- **Horizontal bias**: AF7 vs AF8 alpha asymmetry (Thut et al. 2006)
- **Vertical bias**: theta/alpha ratio (upward gaze → frontal theta)
- **3×3 gaze zone grid**: top-left through bot-right
- Visual engagement from beta/(alpha+beta)
- Sustained attention index from within-session alpha variance
- 3 endpoints: POST /visual-attention/analyze, GET /history/{user_id}, POST /reset/{user_id}
- 20 passing tests

Closes #160