### PR TITLE
feat: altered consciousness state detector (#161)

### DIFF
--- a/ml/api/routes/__init__.py
+++ b/ml/api/routes/__init__.py
@@ -93,6 +93,7 @@ from .meditation_depth_route import router as _meditation_depth
 from .neurogame import router as _neurogame
 from .deception import router as _deception
 from .engagement import router as _engagement
+from .altered_consciousness import router as _altered_consciousness
 
 router = APIRouter()
 
@@ -156,3 +157,4 @@ router.include_router(_meditation_depth)
 router.include_router(_neurogame)
 router.include_router(_deception)
 router.include_router(_engagement)
+router.include_router(_altered_consciousness)

--- a/ml/api/routes/altered_consciousness.py
+++ b/ml/api/routes/altered_consciousness.py
@@ -1,0 +1,72 @@
+"""Altered consciousness state detection API (#161)."""
+from __future__ import annotations
+
+import time
+from collections import defaultdict, deque
+from typing import List
+
+import numpy as np
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+router = APIRouter(prefix="/altered-consciousness", tags=["altered-consciousness"])
+
+
+class AlteredConsciousnessInput(BaseModel):
+    signals: List[List[float]]
+    fs: float = 256.0
+    user_id: str = "default"
+
+
+class AlteredConsciousnessResult(BaseModel):
+    user_id: str
+    state: str
+    altered_consciousness_index: float
+    theta_fraction: float
+    alpha_fraction: float
+    beta_suppression: float
+    spectral_entropy: float
+    model_used: str
+    processed_at: float
+
+
+_history: dict = defaultdict(lambda: deque(maxlen=200))
+
+
+@router.post("/analyze", response_model=AlteredConsciousnessResult)
+async def analyze_altered_consciousness(req: AlteredConsciousnessInput):
+    """Detect altered consciousness state from EEG spectral features."""
+    from models.altered_consciousness import get_model
+    signals = np.array(req.signals, dtype=float)
+    if signals.ndim == 1:
+        signals = signals[np.newaxis, :]
+
+    result = get_model().predict(signals, req.fs)
+
+    out = AlteredConsciousnessResult(
+        user_id=req.user_id,
+        state=result["state"],
+        altered_consciousness_index=result["altered_consciousness_index"],
+        theta_fraction=result["theta_fraction"],
+        alpha_fraction=result["alpha_fraction"],
+        beta_suppression=result["beta_suppression"],
+        spectral_entropy=result["spectral_entropy"],
+        model_used=result["model_used"],
+        processed_at=time.time(),
+    )
+    _history[req.user_id].append(out.model_dump())
+    return out
+
+
+@router.get("/history/{user_id}")
+async def get_history(user_id: str, limit: int = 50):
+    """Return recent altered consciousness analysis history for a user."""
+    items = list(_history[user_id])[-limit:]
+    return {"user_id": user_id, "count": len(items), "history": items}
+
+
+@router.post("/reset/{user_id}")
+async def reset_history(user_id: str):
+    """Clear altered consciousness history for a user."""
+    _history[user_id].clear()
+    return {"user_id": user_id, "status": "reset"}

--- a/ml/models/altered_consciousness.py
+++ b/ml/models/altered_consciousness.py
@@ -1,0 +1,60 @@
+"""Altered consciousness state detector for psychedelic/meditation/hypnosis states.
+
+Altered states show: increased theta/alpha power, reduced beta (default mode
+network suppression), and gamma bursts (ego dissolution correlate).
+
+References:
+    Carhart-Harris et al. (2016) — psilocybin EEG signatures
+    Lutz et al. (2004) — advanced meditation gamma
+    Kihlstrom (1985) — hypnosis theta enhancement
+"""
+from __future__ import annotations
+import numpy as np
+from typing import Dict
+
+STATES = ["normal", "light_altered", "moderate_altered", "deep_altered", "transcendent"]
+
+class AlteredConsciousnessModel:
+    def predict(self, signals: np.ndarray, fs: float = 256.0) -> Dict:
+        if signals.ndim == 1:
+            signals = signals[np.newaxis, :]
+        n_ch, n_samples = signals.shape
+        from scipy.signal import welch
+        nperseg = min(n_samples, int(fs * 2))
+        ch = signals[0]
+        f, psd = welch(ch, fs=fs, nperseg=nperseg)
+        def bp(lo, hi):
+            idx = (f >= lo) & (f <= hi)
+            return float(np.mean(psd[idx])) if idx.any() else 1e-9
+        theta = bp(4, 8); alpha = bp(8, 12); beta = bp(12, 30); gamma = bp(30, 45)
+        total = theta + alpha + beta + gamma + 1e-9
+        # Altered state index: high theta+alpha, low beta, occasional gamma
+        altered_idx = float(np.clip(
+            0.40 * (theta / total) +
+            0.30 * (alpha / total) -
+            0.20 * (beta / total) +
+            0.10 * (gamma / total) + 0.1,
+            0.0, 1.0
+        ))
+        # Entropy proxy: spectral flatness
+        psd_norm = psd / (psd.sum() + 1e-9)
+        spectral_entropy = float(-np.sum(psd_norm * np.log(psd_norm + 1e-12)))
+        spectral_entropy_norm = float(np.clip(spectral_entropy / 5.0, 0, 1))
+        # State mapping
+        if altered_idx < 0.2:   state = "normal"
+        elif altered_idx < 0.35: state = "light_altered"
+        elif altered_idx < 0.50: state = "moderate_altered"
+        elif altered_idx < 0.65: state = "deep_altered"
+        else:                    state = "transcendent"
+        return {
+            "state": state,
+            "altered_consciousness_index": round(altered_idx, 4),
+            "theta_fraction": round(theta / total, 4),
+            "alpha_fraction": round(alpha / total, 4),
+            "beta_suppression": round(1.0 - beta / total, 4),
+            "spectral_entropy": round(spectral_entropy_norm, 4),
+            "model_used": "feature_based_spectral",
+        }
+
+_model = AlteredConsciousnessModel()
+def get_model(): return _model

--- a/ml/tests/test_altered_consciousness.py
+++ b/ml/tests/test_altered_consciousness.py
@@ -1,0 +1,151 @@
+"""Tests for altered consciousness model and API route (#161)."""
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+from fastapi import FastAPI
+
+
+def make_signal(n=512, freq=10.0, fs=256.0, amp=1.0):
+    t = np.linspace(0, n / fs, n)
+    return (amp * np.sin(2 * np.pi * freq * t)).tolist()
+
+
+@pytest.fixture
+def client():
+    from api.routes.altered_consciousness import router
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+def test_model_import():
+    from models.altered_consciousness import AlteredConsciousnessModel, get_model
+    assert AlteredConsciousnessModel is not None
+    assert get_model() is not None
+
+
+def test_predict_1d():
+    from models.altered_consciousness import get_model
+    sig = np.random.randn(512)
+    result = get_model().predict(sig)
+    assert "state" in result
+    assert "altered_consciousness_index" in result
+
+
+def test_predict_2d():
+    from models.altered_consciousness import get_model
+    sig = np.random.randn(4, 512)
+    result = get_model().predict(sig)
+    assert "state" in result
+
+
+def test_state_values():
+    from models.altered_consciousness import get_model
+    states = {"normal", "light_altered", "moderate_altered", "deep_altered", "transcendent"}
+    sig = np.random.randn(512)
+    result = get_model().predict(sig)
+    assert result["state"] in states
+
+
+def test_index_range():
+    from models.altered_consciousness import get_model
+    sig = np.random.randn(512)
+    result = get_model().predict(sig)
+    assert 0.0 <= result["altered_consciousness_index"] <= 1.0
+
+
+def test_theta_fraction_range():
+    from models.altered_consciousness import get_model
+    result = get_model().predict(np.random.randn(512))
+    assert 0.0 <= result["theta_fraction"] <= 1.0
+
+
+def test_alpha_fraction_range():
+    from models.altered_consciousness import get_model
+    result = get_model().predict(np.random.randn(512))
+    assert 0.0 <= result["alpha_fraction"] <= 1.0
+
+
+def test_beta_suppression_range():
+    from models.altered_consciousness import get_model
+    result = get_model().predict(np.random.randn(512))
+    assert 0.0 <= result["beta_suppression"] <= 1.0
+
+
+def test_spectral_entropy_range():
+    from models.altered_consciousness import get_model
+    result = get_model().predict(np.random.randn(512))
+    assert 0.0 <= result["spectral_entropy"] <= 1.0
+
+
+def test_model_used_field():
+    from models.altered_consciousness import get_model
+    result = get_model().predict(np.random.randn(512))
+    assert result["model_used"] == "feature_based_spectral"
+
+
+def test_short_signal():
+    from models.altered_consciousness import get_model
+    sig = np.random.randn(64)
+    result = get_model().predict(sig)
+    assert "state" in result
+
+
+def test_api_analyze(client):
+    payload = {"signals": [make_signal()], "fs": 256.0, "user_id": "u1"}
+    resp = client.post("/altered-consciousness/analyze", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["user_id"] == "u1"
+    assert "state" in data
+
+
+def test_api_analyze_2ch(client):
+    payload = {"signals": [make_signal(), make_signal(freq=6.0)], "fs": 256.0}
+    resp = client.post("/altered-consciousness/analyze", json=payload)
+    assert resp.status_code == 200
+
+
+def test_api_history_empty(client):
+    resp = client.get("/altered-consciousness/history/newuser")
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 0
+
+
+def test_api_history_populated(client):
+    payload = {"signals": [make_signal()], "user_id": "hist_user"}
+    client.post("/altered-consciousness/analyze", json=payload)
+    resp = client.get("/altered-consciousness/history/hist_user")
+    assert resp.json()["count"] >= 1
+
+
+def test_api_reset(client):
+    payload = {"signals": [make_signal()], "user_id": "reset_user"}
+    client.post("/altered-consciousness/analyze", json=payload)
+    resp = client.post("/altered-consciousness/reset/reset_user")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "reset"
+
+
+def test_api_history_after_reset(client):
+    payload = {"signals": [make_signal()], "user_id": "reset2"}
+    client.post("/altered-consciousness/analyze", json=payload)
+    client.post("/altered-consciousness/reset/reset2")
+    resp = client.get("/altered-consciousness/history/reset2")
+    assert resp.json()["count"] == 0
+
+
+def test_api_processed_at(client):
+    payload = {"signals": [make_signal()]}
+    resp = client.post("/altered-consciousness/analyze", json=payload)
+    assert resp.json()["processed_at"] > 0
+
+
+def test_api_history_limit(client):
+    for _ in range(5):
+        client.post("/altered-consciousness/analyze", json={"signals": [make_signal()], "user_id": "limit_user"})
+    resp = client.get("/altered-consciousness/history/limit_user?limit=3")
+    assert resp.json()["count"] <= 3


### PR DESCRIPTION
Implements #161 — Altered Consciousness State Detector.

## Changes
- `ml/models/altered_consciousness.py` — spectral model: theta/alpha fractions + beta suppression + spectral entropy → 5-level state (normal → transcendent)
- `ml/api/routes/altered_consciousness.py` — FastAPI router with `/altered-consciousness/analyze`, `/history/{user_id}`, `/reset/{user_id}`
- `ml/tests/test_altered_consciousness.py` — 19 tests, all passing
- `ml/api/routes/__init__.py` — router registered

Closes #161