### PR TITLE
feat: motor intention ERD decoder for neuroprosthetics (#167)

### DIFF
--- a/ml/api/routes/__init__.py
+++ b/ml/api/routes/__init__.py
@@ -93,6 +93,7 @@ from .meditation_depth_route import router as _meditation_depth
 from .neurogame import router as _neurogame
 from .deception import router as _deception
 from .engagement import router as _engagement
+from .motor_intention import router as _motor_intention
 
 router = APIRouter()
 
@@ -156,3 +157,4 @@ router.include_router(_meditation_depth)
 router.include_router(_neurogame)
 router.include_router(_deception)
 router.include_router(_engagement)
+router.include_router(_motor_intention)

--- a/ml/api/routes/motor_intention.py
+++ b/ml/api/routes/motor_intention.py
@@ -1,0 +1,72 @@
+"""Motor intention BCI decoder API (#167)."""
+from __future__ import annotations
+
+import time
+from collections import defaultdict, deque
+from typing import Dict, List
+
+import numpy as np
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+router = APIRouter(prefix="/motor-intention", tags=["motor-intention"])
+
+
+class MotorIntentionInput(BaseModel):
+    signals: List[List[float]]
+    fs: float = 256.0
+    user_id: str = "default"
+
+
+class MotorIntentionResult(BaseModel):
+    user_id: str
+    intention: str
+    control_signal: float
+    lateral_mu_asymmetry: float
+    lateral_beta_erd: float
+    erd_magnitude: float
+    probabilities: Dict[str, float]
+    model_used: str
+    processed_at: float
+
+
+_history: dict = defaultdict(lambda: deque(maxlen=200))
+
+
+@router.post("/analyze", response_model=MotorIntentionResult)
+async def analyze_motor_intention(req: MotorIntentionInput):
+    """Decode motor intention from mu/beta ERD lateralization."""
+    from models.motor_intention import get_model
+    signals = np.array(req.signals, dtype=float)
+    if signals.ndim == 1:
+        signals = signals[np.newaxis, :]
+
+    result = get_model().predict(signals, req.fs)
+
+    out = MotorIntentionResult(
+        user_id=req.user_id,
+        intention=result["intention"],
+        control_signal=result["control_signal"],
+        lateral_mu_asymmetry=result["lateral_mu_asymmetry"],
+        lateral_beta_erd=result["lateral_beta_erd"],
+        erd_magnitude=result["erd_magnitude"],
+        probabilities=result["probabilities"],
+        model_used=result["model_used"],
+        processed_at=time.time(),
+    )
+    _history[req.user_id].append(out.model_dump())
+    return out
+
+
+@router.get("/history/{user_id}")
+async def get_history(user_id: str, limit: int = 50):
+    """Return recent motor intention history for a user."""
+    items = list(_history[user_id])[-limit:]
+    return {"user_id": user_id, "count": len(items), "history": items}
+
+
+@router.post("/reset/{user_id}")
+async def reset_history(user_id: str):
+    """Clear motor intention history for a user."""
+    _history[user_id].clear()
+    return {"user_id": user_id, "status": "reset"}

--- a/ml/models/motor_intention.py
+++ b/ml/models/motor_intention.py
@@ -1,0 +1,69 @@
+"""EEG neuroprosthetic motor intention decoder.
+
+Motor imagery produces contralateral beta ERD (8-30 Hz) and mu rhythm
+suppression. Left hand imagery suppresses right-hemisphere beta; right hand
+imagery suppresses left-hemisphere beta.
+
+References:
+    Pfurtscheller & Lopes da Silva (1999) — ERD/ERS review
+    McFarland et al. (2000) — EEG-based motor BCI
+    Wolpaw et al. (2002) — BCI for motor prosthetics
+"""
+from __future__ import annotations
+import numpy as np
+from typing import Dict
+
+INTENTIONS = ["rest", "left_hand", "right_hand", "both_hands", "feet"]
+
+class MotorIntentionModel:
+    def predict(self, signals: np.ndarray, fs: float = 256.0) -> Dict:
+        if signals.ndim == 1:
+            signals = signals[np.newaxis, :]
+        n_ch, n_samples = signals.shape
+        from scipy.signal import welch
+        nperseg = min(n_samples, int(fs * 2))
+        def bp(sig, lo, hi):
+            f, p = welch(sig, fs=fs, nperseg=nperseg)
+            idx = (f >= lo) & (f <= hi)
+            return float(np.mean(p[idx])) if idx.any() else 1e-9
+        # Mu band (8-12 Hz) and beta (13-30 Hz) — key for motor imagery
+        if n_ch >= 3:
+            l_mu   = bp(signals[1], 8, 12)   # AF7 (left frontal)
+            r_mu   = bp(signals[2], 8, 12)   # AF8 (right frontal)
+            l_beta = bp(signals[1], 13, 30)
+            r_beta = bp(signals[2], 13, 30)
+        else:
+            l_mu = r_mu = bp(signals[0], 8, 12)
+            l_beta = r_beta = bp(signals[0], 13, 30)
+        # ERD: lower power on contralateral side = motor intention
+        # Left hand → right ERD; Right hand → left ERD
+        lat_mu   = float(np.tanh((np.log(l_mu + 1e-9) - np.log(r_mu + 1e-9)) * 2))
+        lat_beta = float(np.tanh((np.log(l_beta + 1e-9) - np.log(r_beta + 1e-9)) * 2))
+        erd_magnitude = float(np.clip(abs(lat_beta), 0, 1))
+        # Classify intention
+        if erd_magnitude < 0.15:
+            intention, control_signal = "rest", 0.0
+        elif lat_beta > 0.15:      # right ERD → left hand imagery
+            intention, control_signal = "left_hand", float(lat_beta)
+        elif lat_beta < -0.15:     # left ERD → right hand imagery
+            intention, control_signal = "right_hand", float(-lat_beta)
+        elif erd_magnitude > 0.4:  # bilateral ERD → both hands
+            intention, control_signal = "both_hands", erd_magnitude
+        else:
+            intention, control_signal = "feet", float(erd_magnitude * 0.5)
+        probs = {i: 0.05 for i in INTENTIONS}
+        probs[intention] = max(0.5, control_signal)
+        total = sum(probs.values())
+        probs = {k: round(v / total, 4) for k, v in probs.items()}
+        return {
+            "intention": intention,
+            "control_signal": round(control_signal, 4),
+            "lateral_mu_asymmetry": round(lat_mu, 4),
+            "lateral_beta_erd": round(lat_beta, 4),
+            "erd_magnitude": round(erd_magnitude, 4),
+            "probabilities": probs,
+            "model_used": "feature_based_erd_ers",
+        }
+
+_model = MotorIntentionModel()
+def get_model(): return _model

--- a/ml/tests/test_motor_intention.py
+++ b/ml/tests/test_motor_intention.py
@@ -1,0 +1,141 @@
+"""Tests for motor intention model and API route (#167)."""
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+from fastapi import FastAPI
+
+
+INTENTIONS = ["rest", "left_hand", "right_hand", "both_hands", "feet"]
+
+
+def make_signal(n=512, freq=10.0, fs=256.0):
+    t = np.linspace(0, n / fs, n)
+    return (np.sin(2 * np.pi * freq * t)).tolist()
+
+
+@pytest.fixture
+def client():
+    from api.routes.motor_intention import router
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+def test_model_import():
+    from models.motor_intention import MotorIntentionModel, get_model
+    assert MotorIntentionModel is not None
+    assert get_model() is not None
+
+
+def test_predict_1d():
+    from models.motor_intention import get_model
+    result = get_model().predict(np.random.randn(512))
+    assert "intention" in result
+
+
+def test_predict_multichannel():
+    from models.motor_intention import get_model
+    result = get_model().predict(np.random.randn(4, 512))
+    assert "lateral_beta_erd" in result
+
+
+def test_intention_valid():
+    from models.motor_intention import get_model
+    result = get_model().predict(np.random.randn(512))
+    assert result["intention"] in INTENTIONS
+
+
+def test_control_signal_range():
+    from models.motor_intention import get_model
+    result = get_model().predict(np.random.randn(512))
+    assert 0.0 <= result["control_signal"] <= 1.0
+
+
+def test_erd_magnitude_range():
+    from models.motor_intention import get_model
+    result = get_model().predict(np.random.randn(4, 512))
+    assert 0.0 <= result["erd_magnitude"] <= 1.0
+
+
+def test_probabilities_sum():
+    from models.motor_intention import get_model
+    result = get_model().predict(np.random.randn(512))
+    total = sum(result["probabilities"].values())
+    assert abs(total - 1.0) < 0.01
+
+
+def test_probabilities_all_intentions():
+    from models.motor_intention import get_model
+    result = get_model().predict(np.random.randn(4, 512))
+    for intention in INTENTIONS:
+        assert intention in result["probabilities"]
+
+
+def test_lateral_mu_range():
+    from models.motor_intention import get_model
+    result = get_model().predict(np.random.randn(4, 512))
+    assert -1.0 <= result["lateral_mu_asymmetry"] <= 1.0
+
+
+def test_model_used_field():
+    from models.motor_intention import get_model
+    result = get_model().predict(np.random.randn(512))
+    assert "erd" in result["model_used"]
+
+
+def test_short_signal():
+    from models.motor_intention import get_model
+    result = get_model().predict(np.random.randn(64))
+    assert "intention" in result
+
+
+def test_api_analyze(client):
+    payload = {"signals": [make_signal()], "fs": 256.0, "user_id": "u1"}
+    resp = client.post("/motor-intention/analyze", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["intention"] in INTENTIONS
+
+
+def test_api_multichannel(client):
+    payload = {"signals": [make_signal(), make_signal(freq=10.0), make_signal(freq=12.0), make_signal(freq=8.0)]}
+    resp = client.post("/motor-intention/analyze", json=payload)
+    assert resp.status_code == 200
+
+
+def test_api_history_empty(client):
+    resp = client.get("/motor-intention/history/newuser")
+    assert resp.json()["count"] == 0
+
+
+def test_api_history_populated(client):
+    client.post("/motor-intention/analyze", json={"signals": [make_signal()], "user_id": "h_u"})
+    resp = client.get("/motor-intention/history/h_u")
+    assert resp.json()["count"] >= 1
+
+
+def test_api_reset(client):
+    client.post("/motor-intention/analyze", json={"signals": [make_signal()], "user_id": "r_u"})
+    resp = client.post("/motor-intention/reset/r_u")
+    assert resp.json()["status"] == "reset"
+
+
+def test_api_history_after_reset(client):
+    client.post("/motor-intention/analyze", json={"signals": [make_signal()], "user_id": "r2"})
+    client.post("/motor-intention/reset/r2")
+    assert client.get("/motor-intention/history/r2").json()["count"] == 0
+
+
+def test_api_processed_at(client):
+    resp = client.post("/motor-intention/analyze", json={"signals": [make_signal()]})
+    assert resp.json()["processed_at"] > 0
+
+
+def test_api_history_limit(client):
+    for _ in range(5):
+        client.post("/motor-intention/analyze", json={"signals": [make_signal()], "user_id": "lim"})
+    resp = client.get("/motor-intention/history/lim?limit=2")
+    assert resp.json()["count"] <= 2


### PR DESCRIPTION
Implements #167. Lateral mu/beta ERD/ERS → 5 motor intentions (rest/left_hand/right_hand/both_hands/feet). 19 tests passing. Closes #167