### PR TITLE
feat: multimodal EI dashboard (#205)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -64,6 +64,7 @@ const PersonalRecords        = lazy(() => import("@/pages/personal-records"));
 const PrivacyPolicy          = lazy(() => import("@/pages/privacy-policy"));
 const ArchitectureGuide      = lazy(() => import("@/pages/architecture-guide"));
 const SupplementsPage        = lazy(() => import("@/pages/supplements"));
+const EmotionalIntelligence  = lazy(() => import("@/pages/emotional-intelligence"));
 
 // ── Error Boundary — prevents a single page crash from taking down the whole app ──
 class ErrorBoundary extends Component<
@@ -239,6 +240,11 @@ function AppRoutes() {
       <Route path="/supplements">
         <Suspense fallback={<PageLoader />}>
           <AppLayout><SupplementsPage /></AppLayout>
+        </Suspense>
+      </Route>
+      <Route path="/emotional-intelligence">
+        <Suspense fallback={<PageLoader />}>
+          <AppLayout><EmotionalIntelligence /></AppLayout>
         </Suspense>
       </Route>
       {/* Public route — no auth required (needed for App Store / HealthKit) */}

--- a/client/src/components/sidebar.tsx
+++ b/client/src/components/sidebar.tsx
@@ -69,6 +69,7 @@ const sections: NavSection[] = [
   {
     title: "Mind",
     items: [
+      { path: "/emotional-intelligence", label: "EI Dashboard",   icon: Brain },
       { path: "/emotions",        label: "Emotions",         icon: Brain },
       { path: "/insights",        label: "Insights",         icon: Lightbulb },
       { path: "/health-analytics",label: "Health Analytics", icon: BarChart2 },

--- a/client/src/lib/ml-api.ts
+++ b/client/src/lib/ml-api.ts
@@ -1135,3 +1135,40 @@ export async function getActiveSupplements(
 ): Promise<{ user_id: string; hours: number; count: number; supplements: ActiveSupplement[] }> {
   return mlFetch(`/supplements/active/${encodeURIComponent(userId)}?hours=${hours}`);
 }
+
+// ── EI Composite ──────────────────────────────────────────────────────────────
+
+export interface EIQDimensions {
+  self_perception: number;
+  self_expression: number;
+  interpersonal: number;
+  decision_making: number;
+  stress_management: number;
+}
+
+export interface EIQResult {
+  eiq_score: number;
+  eiq_grade: string;
+  dimensions: EIQDimensions;
+  strengths: string[];
+  growth_areas: string[];
+  has_baseline: boolean;
+  processed_at?: number;
+}
+
+export interface EIQSessionStats {
+  n_assessments: number;
+  mean_eiq: number | null;
+  trend: "improving" | "declining" | "stable" | null;
+}
+
+export async function getEIQSessionStats(userId: string): Promise<EIQSessionStats> {
+  return mlFetch<EIQSessionStats>(`/ei-composite/session-stats/${encodeURIComponent(userId)}`);
+}
+
+export async function getEIQHistory(
+  userId: string,
+  limit = 30
+): Promise<{ user_id: string; count: number; history: EIQResult[] }> {
+  return mlFetch(`/ei-composite/history/${encodeURIComponent(userId)}?limit=${limit}`);
+}

--- a/client/src/pages/emotional-intelligence.tsx
+++ b/client/src/pages/emotional-intelligence.tsx
@@ -1,0 +1,370 @@
+/**
+ * /emotional-intelligence — Unified EIQ dashboard (#205)
+ *
+ * Shows:
+ *   • Large EIQ score circle with letter grade
+ *   • 5 dimension bars
+ *   • Sensor contribution panel (EEG / Voice / Health)
+ *   • Strengths & growth areas
+ *   • 30-day EIQ trend chart
+ */
+import { useQuery } from "@tanstack/react-query";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+} from "recharts";
+import {
+  Brain,
+  Mic,
+  Activity,
+  TrendingUp,
+  TrendingDown,
+  Minus,
+  Star,
+  Target,
+} from "lucide-react";
+import {
+  getEIQSessionStats,
+  getEIQHistory,
+  getMultimodalStatus,
+} from "@/lib/ml-api";
+import { getParticipantId } from "@/lib/participant";
+
+const userId = getParticipantId();
+
+// ── Grade colour ──────────────────────────────────────────────────────────────
+
+const GRADE_COLOR: Record<string, string> = {
+  A: "text-green-400",
+  B: "text-emerald-400",
+  C: "text-amber-400",
+  D: "text-orange-400",
+  F: "text-rose-400",
+};
+
+const GRADE_RING: Record<string, string> = {
+  A: "stroke-green-400",
+  B: "stroke-emerald-400",
+  C: "stroke-amber-400",
+  D: "stroke-orange-400",
+  F: "stroke-rose-400",
+};
+
+// ── Dimension labels ───────────────────────────────────────────────────────────
+
+const DIM_LABELS: Record<string, string> = {
+  self_perception: "Self-Perception",
+  self_expression: "Self-Expression",
+  interpersonal: "Interpersonal",
+  decision_making: "Decision-Making",
+  stress_management: "Stress-Management",
+};
+
+const DIM_COLOR: Record<string, string> = {
+  self_perception: "bg-violet-500",
+  self_expression: "bg-blue-500",
+  interpersonal: "bg-teal-500",
+  decision_making: "bg-amber-500",
+  stress_management: "bg-emerald-500",
+};
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function ScoreCircle({ score, grade }: { score: number; grade: string }) {
+  const r = 54;
+  const circ = 2 * Math.PI * r;
+  const dash = (score / 100) * circ;
+  const ringClass = GRADE_RING[grade] ?? "stroke-zinc-500";
+  const textClass = GRADE_COLOR[grade] ?? "text-zinc-400";
+
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <div className="relative w-36 h-36">
+        <svg className="w-full h-full -rotate-90" viewBox="0 0 120 120">
+          <circle cx="60" cy="60" r={r} fill="none" stroke="#27272a" strokeWidth="10" />
+          <circle
+            cx="60" cy="60" r={r}
+            fill="none"
+            strokeWidth="10"
+            strokeLinecap="round"
+            strokeDasharray={`${dash} ${circ}`}
+            className={`transition-all duration-700 ${ringClass}`}
+          />
+        </svg>
+        <div className="absolute inset-0 flex flex-col items-center justify-center">
+          <span className={`text-3xl font-bold tabular-nums ${textClass}`}>{score}</span>
+          <span className="text-xs text-zinc-500">/ 100</span>
+        </div>
+      </div>
+      <Badge className={`text-lg px-3 py-0.5 ${GRADE_COLOR[grade]} bg-zinc-800 border-zinc-700`}>
+        Grade {grade}
+      </Badge>
+    </div>
+  );
+}
+
+function DimensionBar({ name, value }: { name: string; value: number }) {
+  const color = DIM_COLOR[name] ?? "bg-zinc-500";
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between text-xs">
+        <span className="text-zinc-300">{DIM_LABELS[name] ?? name}</span>
+        <span className="tabular-nums text-zinc-400">{value.toFixed(1)}</span>
+      </div>
+      <div className="h-2 bg-zinc-800 rounded-full overflow-hidden">
+        <div
+          className={`h-full rounded-full transition-all duration-500 ${color}`}
+          style={{ width: `${Math.min(value, 100)}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function SensorChip({
+  icon: Icon,
+  label,
+  active,
+  weight,
+  color,
+}: {
+  icon: React.ElementType;
+  label: string;
+  active: boolean;
+  weight: number;
+  color: string;
+}) {
+  return (
+    <div
+      className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-sm ${
+        active
+          ? `border-${color}-500/40 bg-${color}-500/10 text-${color}-300`
+          : "border-zinc-800 bg-zinc-900/40 text-zinc-500"
+      }`}
+    >
+      <Icon className="h-4 w-4 shrink-0" />
+      <div className="flex-1 min-w-0">
+        <p className="font-medium leading-tight">{label}</p>
+        <p className="text-xs opacity-70">
+          {active ? `${Math.round(weight * 100)}% weight` : "offline"}
+        </p>
+      </div>
+      <div className={`h-2 w-2 rounded-full ${active ? `bg-${color}-400` : "bg-zinc-700"}`} />
+    </div>
+  );
+}
+
+function TrendIcon({ trend }: { trend: string | null }) {
+  if (trend === "improving")
+    return <TrendingUp className="h-4 w-4 text-green-400" />;
+  if (trend === "declining")
+    return <TrendingDown className="h-4 w-4 text-rose-400" />;
+  return <Minus className="h-4 w-4 text-zinc-400" />;
+}
+
+// ── Main page ─────────────────────────────────────────────────────────────────
+
+export default function EmotionalIntelligencePage() {
+  const statsQ = useQuery({
+    queryKey: ["eiq-stats", userId],
+    queryFn: () => getEIQSessionStats(userId),
+    refetchInterval: 60_000,
+  });
+
+  const histQ = useQuery({
+    queryKey: ["eiq-history", userId],
+    queryFn: () => getEIQHistory(userId, 30),
+    refetchInterval: 60_000,
+  });
+
+  const modalQ = useQuery({
+    queryKey: ["multimodal-status"],
+    queryFn: getMultimodalStatus,
+    refetchInterval: 30_000,
+  });
+
+  // Latest EIQ entry
+  const history = histQ.data?.history ?? [];
+  const latest = history.length > 0 ? history[history.length - 1] : null;
+  const fw = modalQ.data?.fusion_weights ?? { eeg: 0.5, audio: 0, video: 0 };
+
+  // Chart data
+  const chartData = history.map((h, i) => ({
+    idx: i + 1,
+    eiq: h.eiq_score,
+  }));
+
+  const loading = statsQ.isLoading || histQ.isLoading;
+
+  return (
+    <div className="max-w-2xl mx-auto p-4 space-y-4">
+      {/* Header */}
+      <div className="flex items-center gap-2">
+        <Brain className="h-5 w-5 text-violet-400" />
+        <h1 className="text-xl font-semibold text-white">Emotional Intelligence</h1>
+        {statsQ.data?.trend && (
+          <TrendIcon trend={statsQ.data.trend} />
+        )}
+      </div>
+      <p className="text-sm text-zinc-400">
+        Composite EIQ from EEG brain signals, voice patterns, and health data.
+      </p>
+
+      {loading && (
+        <p className="text-xs text-zinc-500 animate-pulse">Loading EIQ data…</p>
+      )}
+
+      {!loading && !latest && (
+        <Card className="bg-zinc-900/60 border-zinc-800">
+          <CardContent className="p-6 text-center text-sm text-zinc-500">
+            No EIQ assessments yet. Run an EEG session and the score will appear here.
+          </CardContent>
+        </Card>
+      )}
+
+      {latest && (
+        <>
+          {/* Score + stats row */}
+          <div className="grid grid-cols-[auto,1fr] gap-4 items-start">
+            <ScoreCircle score={latest.eiq_score} grade={latest.eiq_grade} />
+            <div className="space-y-2 pt-2">
+              <div className="flex gap-3 text-sm">
+                <div>
+                  <p className="text-zinc-500 text-xs">Sessions</p>
+                  <p className="text-white font-semibold">{statsQ.data?.n_assessments ?? "—"}</p>
+                </div>
+                <div>
+                  <p className="text-zinc-500 text-xs">Average</p>
+                  <p className="text-white font-semibold">
+                    {statsQ.data?.mean_eiq != null ? statsQ.data.mean_eiq.toFixed(1) : "—"}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-zinc-500 text-xs">Trend</p>
+                  <p className="text-white font-semibold capitalize">
+                    {statsQ.data?.trend ?? "—"}
+                  </p>
+                </div>
+              </div>
+
+              {/* Strengths */}
+              {latest.strengths.length > 0 && (
+                <div>
+                  <p className="text-xs text-zinc-500 mb-1 flex items-center gap-1">
+                    <Star className="h-3 w-3 text-amber-400" /> Strengths
+                  </p>
+                  <div className="flex flex-wrap gap-1">
+                    {latest.strengths.map((s) => (
+                      <Badge key={s} className="text-xs bg-amber-500/10 text-amber-300 border-amber-500/30">
+                        {DIM_LABELS[s] ?? s}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Growth areas */}
+              {latest.growth_areas.length > 0 && (
+                <div>
+                  <p className="text-xs text-zinc-500 mb-1 flex items-center gap-1">
+                    <Target className="h-3 w-3 text-blue-400" /> Growth areas
+                  </p>
+                  <div className="flex flex-wrap gap-1">
+                    {latest.growth_areas.map((g) => (
+                      <Badge key={g} className="text-xs bg-blue-500/10 text-blue-300 border-blue-500/30">
+                        {DIM_LABELS[g] ?? g}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* 5 Dimension bars */}
+          <Card className="bg-zinc-900/60 border-zinc-800">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm text-zinc-300">5 EI Dimensions</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {Object.entries(latest.dimensions).map(([dim, val]) => (
+                <DimensionBar key={dim} name={dim} value={val} />
+              ))}
+            </CardContent>
+          </Card>
+
+          {/* Sensor contribution */}
+          <Card className="bg-zinc-900/60 border-zinc-800">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm text-zinc-300">Active Sensors</CardTitle>
+            </CardHeader>
+            <CardContent className="grid grid-cols-3 gap-2">
+              <SensorChip
+                icon={Brain}
+                label="EEG"
+                active={modalQ.data?.eeg_model_loaded ?? false}
+                weight={fw.eeg}
+                color="violet"
+              />
+              <SensorChip
+                icon={Mic}
+                label="Voice"
+                active={modalQ.data?.audio_model_loaded ?? false}
+                weight={fw.audio}
+                color="blue"
+              />
+              <SensorChip
+                icon={Activity}
+                label="Health"
+                active={false}
+                weight={0}
+                color="purple"
+              />
+            </CardContent>
+          </Card>
+
+          {/* Trend chart */}
+          {chartData.length > 1 && (
+            <Card className="bg-zinc-900/60 border-zinc-800">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm text-zinc-300 flex items-center gap-2">
+                  <TrendingUp className="h-4 w-4" /> EIQ Trend
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ResponsiveContainer width="100%" height={140}>
+                  <LineChart data={chartData}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="#27272a" />
+                    <XAxis dataKey="idx" tick={{ fontSize: 10, fill: "#71717a" }} />
+                    <YAxis domain={[0, 100]} tick={{ fontSize: 10, fill: "#71717a" }} />
+                    <Tooltip
+                      contentStyle={{ background: "#18181b", border: "1px solid #3f3f46", borderRadius: 8 }}
+                      labelStyle={{ color: "#a1a1aa" }}
+                      itemStyle={{ color: "#a78bfa" }}
+                      formatter={(v: number) => [v.toFixed(1), "EIQ"]}
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="eiq"
+                      stroke="#a78bfa"
+                      strokeWidth={2}
+                      dot={false}
+                      activeDot={{ r: 4, fill: "#a78bfa" }}
+                    />
+                  </LineChart>
+                </ResponsiveContainer>
+              </CardContent>
+            </Card>
+          )}
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New `/emotional-intelligence` page — unified EIQ dashboard
- EIQ score circle (0-100) with letter grade A–F, colour-coded by grade
- 5 dimension bars: Self-Perception, Self-Expression, Interpersonal, Decision-Making, Stress-Management
- Sensor contribution panel: EEG / Voice / Health with live weights from `/multimodal/status`
- Strengths & growth areas highlighted with badges
- Session stats: n assessments, mean EIQ, trend
- 30-entry trend line chart (Recharts)
- Added `getEIQSessionStats` + `getEIQHistory` to `ml-api.ts`

Closes #205