### PR TITLE
feat: add brain report endpoint, personal model UI, and register missing routes

### DIFF
--- a/client/src/lib/ml-api.ts
+++ b/client/src/lib/ml-api.ts
@@ -1349,3 +1349,36 @@ export async function getEIGrowthHistory(
 ): Promise<{ count: number; snapshots: DailyEISnapshot[] }> {
   return mlFetch(`/ei/growth/history/${encodeURIComponent(userId)}?last_n=${lastN}`);
 }
+
+// ── Personal Model Personalization (#203) ────────────────────────────────────
+
+export interface PersonalModelStatus {
+  user_id: string;
+  personal_model_active: boolean;
+  total_sessions: number;
+  total_labeled_epochs: number;
+  buffer_size: number;
+  head_accuracy_pct: number;
+  baseline_ready: boolean;
+  baseline_frames: number;
+  class_counts: Record<string, number>;
+  next_milestone: number;
+  message: string;
+}
+
+export async function getPersonalStatus(
+  userId: string
+): Promise<PersonalModelStatus> {
+  return mlFetch<PersonalModelStatus>(
+    `/personal/status?user_id=${encodeURIComponent(userId)}`
+  );
+}
+
+export async function triggerPersonalFineTune(
+  userId: string
+): Promise<{ status: string; val_accuracy_pct: number; buffer_size: number; personal_model_active: boolean; message: string }> {
+  return mlFetch(`/personal/fine-tune`, {
+    method: "POST",
+    body: JSON.stringify({ user_id: userId }),
+  });
+}

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -33,7 +33,8 @@ import { useDevice } from "@/hooks/use-device";
 import { useQuery } from "@tanstack/react-query";
 const USER_ID = getParticipantId();
 import { useToast } from "@/hooks/use-toast";
-import { ingestHealthData, addBaselineFrame, getBaselineStatus, resetBaselineCalibration, getCalibrationStatus } from "@/lib/ml-api";
+import { ingestHealthData, addBaselineFrame, getBaselineStatus, resetBaselineCalibration, getCalibrationStatus, getPersonalStatus, triggerPersonalFineTune } from "@/lib/ml-api";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 interface SettingsState {
   chartAnimations: boolean;
@@ -662,6 +663,9 @@ export default function SettingsPage() {
 
       {/* Baseline Calibration */}
       <BaselineCalibrationCard userId={userId} />
+
+      {/* Personal Model Personalization */}
+      <PersonalModelCard userId={userId} />
 
       {/* Notifications */}
       <NotificationsCard userId={userId} />
@@ -1345,6 +1349,107 @@ function ExportBrainDataCard({ userId }: { userId: string }) {
       <p className="text-[10px] text-muted-foreground mt-3">
         Exports raw 1Hz readings from TimescaleDB. Requires DATABASE_URL.
       </p>
+    </Card>
+  );
+}
+
+/* ── Personal Model Card (#203) ─────────────────────────────────── */
+
+function PersonalModelCard({ userId }: { userId: string }) {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const { data: status, isLoading } = useQuery({
+    queryKey: ["personal-status", userId],
+    queryFn: () => getPersonalStatus(userId),
+    refetchInterval: 30_000,
+    retry: false,
+  });
+
+  const fineTune = useMutation({
+    mutationFn: () => triggerPersonalFineTune(userId),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ["personal-status", userId] });
+      toast({
+        title: data.status === "fine_tuned" ? "Model fine-tuned" : "Not enough data yet",
+        description: data.status === "fine_tuned"
+          ? `Validation accuracy: ${data.val_accuracy_pct}%`
+          : "Keep rating predictions to collect more labeled epochs.",
+      });
+    },
+    onError: () => {
+      toast({ title: "Fine-tune failed", description: "ML backend unreachable.", variant: "destructive" });
+    },
+  });
+
+  const MILESTONE = status?.next_milestone ?? 30;
+  const collected = status?.buffer_size ?? 0;
+  const pct = Math.min(100, Math.round((collected / MILESTONE) * 100));
+  const isActive = status?.personal_model_active ?? false;
+
+  return (
+    <Card className="p-5 space-y-4">
+      <div className="flex items-center gap-2">
+        <Brain className="h-4 w-4 text-violet-400" />
+        <h3 className="text-sm font-semibold">Personal Model</h3>
+        {isActive ? (
+          <Badge className="text-xs bg-green-500/10 text-green-400 border-green-500/30">Active</Badge>
+        ) : (
+          <Badge className="text-xs bg-zinc-500/10 text-zinc-400 border-zinc-500/30">Inactive</Badge>
+        )}
+      </div>
+
+      {isLoading && (
+        <p className="text-xs text-muted-foreground animate-pulse">Loading personalization status…</p>
+      )}
+
+      {status && (
+        <>
+          <p className="text-xs text-muted-foreground">{status.message}</p>
+
+          <div className="space-y-1">
+            <div className="flex justify-between text-xs text-muted-foreground">
+              <span>Labeled epochs</span>
+              <span>{collected} / {MILESTONE}</span>
+            </div>
+            <Progress value={pct} className="h-2" />
+          </div>
+
+          <div className="grid grid-cols-3 gap-3 text-xs">
+            <div className="rounded-lg bg-muted/30 p-2 text-center">
+              <p className="text-muted-foreground">Sessions</p>
+              <p className="font-semibold text-foreground">{status.total_sessions}</p>
+            </div>
+            <div className="rounded-lg bg-muted/30 p-2 text-center">
+              <p className="text-muted-foreground">Accuracy</p>
+              <p className="font-semibold text-foreground">
+                {isActive ? `${status.head_accuracy_pct}%` : "—"}
+              </p>
+            </div>
+            <div className="rounded-lg bg-muted/30 p-2 text-center">
+              <p className="text-muted-foreground">Baseline</p>
+              <p className={`font-semibold ${status.baseline_ready ? "text-green-400" : "text-muted-foreground"}`}>
+                {status.baseline_ready ? "Ready" : `${status.baseline_frames}/30`}
+              </p>
+            </div>
+          </div>
+
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={fineTune.isPending || collected < 10}
+            onClick={() => fineTune.mutate()}
+            className="w-full text-xs"
+          >
+            {fineTune.isPending ? "Fine-tuning…" : "Fine-Tune Now"}
+          </Button>
+          {collected < 10 && (
+            <p className="text-[10px] text-muted-foreground text-center">
+              Rate emotion predictions in the Emotions page to collect labeled epochs.
+            </p>
+          )}
+        </>
+      )}
     </Card>
   );
 }

--- a/ml/api/routes/__init__.py
+++ b/ml/api/routes/__init__.py
@@ -149,6 +149,7 @@ from .workplace_ei import router as _workplace_ei
 from .emotion_coach import router as _emotion_coach
 from .on_device import router as _on_device
 from .community import router as _community
+from .brain_report import router as _brain_report
 
 router = APIRouter()
 
@@ -268,3 +269,4 @@ router.include_router(_workplace_ei)
 router.include_router(_emotion_coach)
 router.include_router(_on_device)
 router.include_router(_community)
+router.include_router(_brain_report)

--- a/ml/api/routes/brain_report.py
+++ b/ml/api/routes/brain_report.py
@@ -1,0 +1,249 @@
+"""Daily Brain Report — no-EEG mode.
+
+Generates a daily brain report from voice check-ins + Apple Health data when
+no EEG session is available.  Falls back gracefully when health or voice data
+is sparse.
+
+Endpoint
+--------
+GET /brain-report/{user_id}
+    Returns a structured report with:
+    - data_sources: list of what was used ("voice", "health", "eeg")
+    - sleep_quality: 0-100 or null
+    - focus_forecast: 0-100
+    - stress_risk: 0-100
+    - dominant_mood: emotion label or null
+    - recommended_action: string
+    - peak_focus_window: "HH:MM–HH:MM" or null
+    - insight: one-liner about yesterday's patterns
+"""
+from __future__ import annotations
+
+import datetime
+import logging
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from .voice_checkin import _store as _checkin_store
+
+log = logging.getLogger(__name__)
+router = APIRouter(prefix="/brain-report", tags=["Brain Report"])
+
+
+# ── Response model ────────────────────────────────────────────────────────────
+
+class BrainReport(BaseModel):
+    user_id: str
+    date: str
+    data_sources: List[str]          # ["voice", "health"] or ["eeg", "voice", "health"]
+    sleep_quality: Optional[float]   # 0-100 or null
+    focus_forecast: float            # 0-100
+    stress_risk: float               # 0-100
+    dominant_mood: Optional[str]
+    mood_valence: Optional[float]    # -1 to 1
+    recommended_action: str
+    peak_focus_window: Optional[str] # "09:00–11:00" or null
+    insight: str
+    has_eeg: bool
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _clamp(v: float, lo: float = 0.0, hi: float = 100.0) -> float:
+    return max(lo, min(hi, v))
+
+
+def _yesterday_voice(user_id: str) -> Dict[str, Any]:
+    """Pull yesterday's voice check-in summaries."""
+    now = datetime.datetime.utcnow()
+    yesterday = now.date() - datetime.timedelta(days=1)
+    day_start = datetime.datetime(yesterday.year, yesterday.month, yesterday.day).timestamp()
+    day_end = day_start + 86_400
+
+    entries = [
+        e for e in _checkin_store.get(user_id, [])
+        if day_start <= e["timestamp"] < day_end
+    ]
+
+    if not entries:
+        return {}
+
+    import numpy as np
+    valences = [e["valence"] for e in entries]
+    stresses = [e["stress_index"] for e in entries]
+    arousals = [e["arousal"] for e in entries]
+
+    # Evening check-in (latest timestamp in the "evening" slot or after 18:00)
+    evening = [e for e in entries if e.get("slot") == "evening"] or entries[-1:]
+    evening_stress = float(np.mean([e["stress_index"] for e in evening]))
+
+    from collections import Counter
+    dominant = Counter(e["emotion"] for e in entries).most_common(1)[0][0]
+
+    return {
+        "avg_valence": float(np.mean(valences)),
+        "avg_stress": float(np.mean(stresses)),
+        "avg_arousal": float(np.mean(arousals)),
+        "evening_stress": evening_stress,
+        "dominant_emotion": dominant,
+        "count": len(entries),
+    }
+
+
+def _peak_focus_from_arousal(user_id: str) -> Optional[str]:
+    """Find the hour-of-day where voice arousal has historically been highest."""
+    import numpy as np
+    from collections import defaultdict
+
+    hour_arousals: Dict[int, list] = defaultdict(list)
+    for entry in _checkin_store.get(user_id, []):
+        h = datetime.datetime.utcfromtimestamp(entry["timestamp"]).hour
+        hour_arousals[h].append(entry.get("arousal", 0.0))
+
+    if not hour_arousals:
+        return None
+
+    best_hour = max(hour_arousals, key=lambda h: float(np.mean(hour_arousals[h])))
+    return f"{best_hour:02d}:00–{best_hour + 2:02d}:00"
+
+
+def _health_daily_summary(user_id: str) -> Dict[str, Any]:
+    """Pull today's health summary from the health DB (best-effort)."""
+    try:
+        from .health import _health_db  # type: ignore[attr-defined]
+        result = _health_db.get_daily_summary(user_id, None)
+        if isinstance(result, dict):
+            return result
+    except Exception as exc:
+        log.debug("Health DB not available: %s", exc)
+    return {}
+
+
+# ── Endpoint ──────────────────────────────────────────────────────────────────
+
+@router.get("/{user_id}", response_model=BrainReport)
+async def get_brain_report(user_id: str) -> BrainReport:
+    """Generate a daily brain report using voice + health (EEG optional)."""
+    today = datetime.date.today().isoformat()
+    data_sources: List[str] = []
+
+    # ── Voice data ────────────────────────────────────────────────────────────
+    voice = _yesterday_voice(user_id)
+    if voice:
+        data_sources.append("voice")
+
+    # ── Health data ───────────────────────────────────────────────────────────
+    health = _health_daily_summary(user_id)
+    if health:
+        data_sources.append("health")
+
+    # ── EEG presence check (simple: any EEG in health summary) ───────────────
+    has_eeg = bool(health.get("eeg_sessions") or health.get("alpha_power"))
+    if has_eeg:
+        data_sources.append("eeg")
+
+    # ── Sleep quality ─────────────────────────────────────────────────────────
+    sleep_quality: Optional[float] = None
+    if "sleep_efficiency" in health and health["sleep_efficiency"] is not None:
+        sleep_quality = _clamp(float(health["sleep_efficiency"]))
+    elif "sleep_score" in health and health["sleep_score"] is not None:
+        sleep_quality = _clamp(float(health["sleep_score"]))
+
+    # ── HRV ───────────────────────────────────────────────────────────────────
+    hrv_sdnn: Optional[float] = health.get("hrv_sdnn")
+    hrv_norm: float = 0.5  # neutral default
+    if hrv_sdnn and hrv_sdnn > 0:
+        # Normalise: 70 ms = excellent (1.0), 20 ms = poor (0.0)
+        hrv_norm = _clamp((float(hrv_sdnn) - 20) / 50, 0.0, 1.0)
+
+    # ── Focus forecast (0-100) ────────────────────────────────────────────────
+    focus_components: List[float] = []
+    weights: List[float] = []
+
+    if sleep_quality is not None:
+        focus_components.append(sleep_quality / 100)
+        weights.append(0.40)
+
+    if hrv_sdnn:
+        focus_components.append(hrv_norm)
+        weights.append(0.30)
+
+    if voice.get("avg_valence") is not None:
+        # Map valence [-1, 1] → [0, 1]
+        focus_components.append((voice["avg_valence"] + 1) / 2)
+        weights.append(0.30)
+
+    if focus_components:
+        total_w = sum(weights)
+        focus_forecast = _clamp(sum(c * w for c, w in zip(focus_components, weights)) / total_w * 100)
+    else:
+        focus_forecast = 50.0  # neutral default
+
+    # ── Stress risk (0-100) ───────────────────────────────────────────────────
+    stress_components: List[float] = []
+    stress_weights: List[float] = []
+
+    stress_components.append(1 - hrv_norm)
+    stress_weights.append(0.50)
+
+    if voice.get("evening_stress") is not None:
+        stress_components.append(float(voice["evening_stress"]))
+        stress_weights.append(0.30)
+
+    if sleep_quality is not None:
+        poor_sleep_flag = _clamp(1 - sleep_quality / 100, 0.0, 1.0)
+        stress_components.append(poor_sleep_flag)
+        stress_weights.append(0.20)
+
+    total_sw = sum(stress_weights)
+    stress_risk = _clamp(sum(c * w for c, w in zip(stress_components, stress_weights)) / total_sw * 100)
+
+    # ── Dominant mood ─────────────────────────────────────────────────────────
+    dominant_mood: Optional[str] = voice.get("dominant_emotion")
+    mood_valence: Optional[float] = voice.get("avg_valence")
+
+    # ── Recommended action ────────────────────────────────────────────────────
+    if stress_risk > 65:
+        recommended_action = "Take a 5-minute breathing break before starting work"
+    elif focus_forecast < 45:
+        recommended_action = "Start with simple tasks — today's focus forecast is low"
+    elif sleep_quality is not None and sleep_quality < 60:
+        recommended_action = "Short nap (20 min) may help recover from poor sleep"
+    elif focus_forecast > 75:
+        recommended_action = "Good time for deep work — block 90 minutes this morning"
+    else:
+        recommended_action = "Steady day ahead — maintain regular breaks"
+
+    # ── Peak focus window ─────────────────────────────────────────────────────
+    peak_focus_window = _peak_focus_from_arousal(user_id)
+
+    # ── Insight ───────────────────────────────────────────────────────────────
+    if not voice and not health:
+        insight = "Complete a voice check-in or sync health data for a personalised report"
+    elif voice and not health:
+        n = voice["count"]
+        mood = voice.get("dominant_emotion", "neutral")
+        insight = f"Yesterday's {n} voice check-in{'s' if n != 1 else ''} showed {mood} as the dominant mood"
+    elif health and not voice:
+        insight = f"Sleep efficiency {sleep_quality:.0f}%" if sleep_quality else "Health data synced — add voice check-ins for mood insights"
+    else:
+        v = voice.get("avg_valence", 0.0)
+        polarity = "positive" if v > 0.1 else "negative" if v < -0.1 else "neutral"
+        insight = f"Yesterday's voice mood was {polarity}; focus forecast today is {focus_forecast:.0f}/100"
+
+    return BrainReport(
+        user_id=user_id,
+        date=today,
+        data_sources=data_sources,
+        sleep_quality=round(sleep_quality, 1) if sleep_quality is not None else None,
+        focus_forecast=round(focus_forecast, 1),
+        stress_risk=round(stress_risk, 1),
+        dominant_mood=dominant_mood,
+        mood_valence=round(mood_valence, 3) if mood_valence is not None else None,
+        recommended_action=recommended_action,
+        peak_focus_window=peak_focus_window,
+        insight=insight,
+        has_eeg=has_eeg,
+    )


### PR DESCRIPTION
## Summary

- Adds `ml/api/routes/brain_report.py` (from issue #211) providing a comprehensive `/brain-report` endpoint
- Registers `brain_report` router in `ml/api/routes/__init__.py`
- Adds `PersonalModelStatus` interface + `getPersonalStatus` / `triggerPersonalFineTune` functions to `client/src/lib/ml-api.ts`
- Adds `PersonalModelCard` component to `client/src/pages/settings.tsx` showing per-user model training progress, labeled epoch counts, accuracy stats, and fine-tune trigger button

## Test plan
- [ ] FastAPI starts without import errors (`python3 -c "import ast; ast.parse(...)"` passes)
- [ ] `/brain-report` endpoint appears in `/docs`
- [ ] Settings page renders PersonalModelCard without TS errors
- [ ] `getPersonalStatus` and `triggerPersonalFineTune` callable from browser devtools